### PR TITLE
refactor composer.json - licence&dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
     "name": "symfony-cmf/seo-bundle",
-    "keywords": ["Symfony CMF"],
+    "type": "symfony-bundle",
+    "description": "Symfony CMF Search Engine Optimization Bundle",
+    "keywords": ["Symfony CMF", "SEO"],
     "homepage": "http://cmf.symfony.com",
     "license": "MIT",
     "authors": [
@@ -14,7 +16,7 @@
         "php": ">=5.3.3",
         "symfony-cmf/routing-bundle": "1.2.*@dev",
         "symfony-cmf/core-bundle": "1.1.*@dev",
-        "sonata-project/seo-bundle": "1.1.4"
+        "sonata-project/seo-bundle": "1.1.*@dev"
     },
     "require-dev": {
         "symfony-cmf/testing": "dev-master",


### PR DESCRIPTION
fix #49 

While adding the licence data and contributes i go over the dependencies.
@WouterJ can you have a look?
I thought first routing-bundle would be enough but then i recognized the dependency to core-bundle.
For sure the sonata-project/SeoBundle is the main dependency.
