### PR TITLE
fix naming

### DIFF
--- a/Doctrine/Phpcr/SeoAwareContent.php
+++ b/Doctrine/Phpcr/SeoAwareContent.php
@@ -23,7 +23,7 @@ class SeoAwareContent extends SeoAwareContentModel
     /**
      * The parent node.
      */
-    protected $parent;
+    protected $parentDocument;
 
     /**
      * @param mixed $node
@@ -44,16 +44,16 @@ class SeoAwareContent extends SeoAwareContentModel
     /**
      * @param mixed $parent
      */
-    public function setParent($parent)
+    public function setParentDocument($parent)
     {
-        $this->parent = $parent;
+        $this->parentDocument = $parent;
     }
 
     /**
      * @return mixed
      */
-    public function getParent()
+    public function getParentDocument()
     {
-        return $this->parent;
+        return $this->parentDocument;
     }
 }

--- a/Resources/config/doctrine-phpcr/SeoAwareContent.phpcr.xml
+++ b/Resources/config/doctrine-phpcr/SeoAwareContent.phpcr.xml
@@ -4,12 +4,11 @@
         xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
         https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd"
         >
-
     <document name="Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SeoAwareContent">
         <id name="id">
             <generator strategy="PARENT"/>
         </id>
         <node name="node"/>
-        <parent-document name="parent"/>
+        <parent-document name="parentDocument"/>
     </document>
 </doctrine-mapping>

--- a/Tests/Functional/Doctrine/Phpcr/SeoMetadataPersistenceTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/SeoMetadataPersistenceTest.php
@@ -47,7 +47,7 @@ class SeoMetadataPersistenceTest extends BaseTestCase
 
         $content = new SeoAwareContent();
         $refl = new \ReflectionClass($content);
-        $content->setParent($this->base);
+        $content->setParentDocument($this->base);
         foreach ($documentData as $key => $value) {
             $refl = new \ReflectionClass($content);
             $prop = $refl->getProperty($key);

--- a/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
@@ -42,7 +42,7 @@ class LoadContentData implements FixtureInterface, DependentFixtureInterface
         $content = new SeoAwareContent();
         $content->setTitle('Content 1');
         $content->setBody('Content 1');
-        $content->setParent($contentRoot);
+        $content->setParentDocument($contentRoot);
         $metadata = new SeoMetadata();
         $metadata->setTitle('Title content 1');
         $metadata->setMetaDescription('Description of content 1.');
@@ -61,7 +61,7 @@ class LoadContentData implements FixtureInterface, DependentFixtureInterface
         $strategyContent = new SeoAwareContent();
         $strategyContent->setTitle('Strategy title');
         $strategyContent->setBody('content of strategy test.');
-        $strategyContent->setParent($contentRoot);
+        $strategyContent->setParentDocument($contentRoot);
         //insert empty meta data
         $strategyMetadata = new SeoMetadata();
         $strategyMetadata->setTitle('');


### PR DESCRIPTION
just forget to follow the naming strategy for parent document as the other cmf bundles do. fix #76 
