### PR TITLE
fix: name instead of names in metatags

### DIFF
--- a/Model/SeoPresentation.php
+++ b/Model/SeoPresentation.php
@@ -157,7 +157,7 @@ class SeoPresentation implements SeoPresentationInterface
                 : $seoMetadata->getTitle();
 
             $this->sonataPage->setTitle($pageTitle);
-            $this->sonataPage->addMeta('names', 'title', $pageTitle);
+            $this->sonataPage->addMeta('name', 'title', $pageTitle);
         }
 
         if ($seoMetadata->getMetaDescription()) {
@@ -170,7 +170,7 @@ class SeoPresentation implements SeoPresentationInterface
                 : $seoMetadata->getMetaDescription();
 
             $this->sonataPage->addMeta(
-                'names',
+                'name',
                 'description',
                 $pageDescription
             );
@@ -178,7 +178,7 @@ class SeoPresentation implements SeoPresentationInterface
 
         if ($seoMetadata->getMetaKeywords()) {
             $this->sonataPage->addMeta(
-                'names',
+                'name',
                 'keywords',
                 $this->createKeywords($seoMetadata->getMetaKeywords())
             );
@@ -211,8 +211,8 @@ class SeoPresentation implements SeoPresentationInterface
     private function createKeywords($contentKeywords)
     {
         $metas = $this->sonataPage->getMetas();
-        $sonataKeywords = isset($metas['names']['keywords'][0])
-           ? $metas['names']['keywords'][0]
+        $sonataKeywords = isset($metas['name']['keywords'][0])
+           ? $metas['name']['keywords'][0]
            : '';
 
         return ('' !== $sonataKeywords ? $sonataKeywords.', ' : '') . $contentKeywords;

--- a/Tests/Unit/Model/SeoPresentationTest.php
+++ b/Tests/Unit/Model/SeoPresentationTest.php
@@ -125,7 +125,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
         $this->seoPresentation->updateSeoPage($this->document);
 
         $metas = $this->pageService->getMetas();
-        $actualDescription = $metas['names']['description'][0];
+        $actualDescription = $metas['name']['description'][0];
         $this->assertEquals('Default Description. Test description.', $actualDescription);
     }
 
@@ -136,7 +136,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
         $this->seoPresentation->updateSeoPage($this->document);
 
         $metas = $this->pageService->getMetas();
-        $actualDescription = $metas['names']['description'][0];
+        $actualDescription = $metas['name']['description'][0];
         $this->assertEquals('Content description.', $actualDescription);
     }
 
@@ -144,12 +144,12 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
     {
         $this->seoMetadata->setMetaKeywords('key1, key2');
         //to set it here is the same as it was set in the sonata_seo settings
-        $this->pageService->addMeta('names', 'keywords', 'default, other');
+        $this->pageService->addMeta('name', 'keywords', 'default, other');
         $this->seoPresentation->updateSeoPage($this->document);
         $keywords = $this->pageService->getMetas();
         $this->assertEquals(
             'default, other, key1, key2',
-            $keywords['names']['keywords'][0]
+            $keywords['name']['keywords'][0]
         );
     }
 
@@ -168,7 +168,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
         $seoPresentation->updateSeoPage(new AllStrategiesDocument());
 
         $metas = $this->pageService->getMetas();
-        $actualDescription = $metas['names']['description'][0];
+        $actualDescription = $metas['name']['description'][0];
         $this->assertEquals('translation strategy test', $actualDescription);
 
         $this->assertEquals('translation strategy test', $this->pageService->getTitle());

--- a/Tests/WebTest/SeoFrontendTest.php
+++ b/Tests/WebTest/SeoFrontendTest.php
@@ -58,9 +58,9 @@ class SeoFrontendTest extends BaseTestCase
 
         //test the meta tag entries
         $metaCrawler = $crawler->filter('head > meta')->reduce(function (Crawler $node) {
-                $namesValue = $node->attr('names');
+                $nameValue = $node->attr('name');
 
-                return 'title' === $namesValue || 'description' === $namesValue ||'keywords' === $namesValue;
+                return 'title' === $nameValue || 'description' === $nameValue ||'keywords' === $nameValue;
         });
 
         $actualMeta = $metaCrawler->extract('content', 'content');
@@ -92,9 +92,9 @@ class SeoFrontendTest extends BaseTestCase
 
         //test the meta tag entries
         $metaCrawler = $crawler->filter('head > meta')->reduce(function (Crawler $node) {
-            $namesValue = $node->attr('names');
+            $nameValue = $node->attr('name');
 
-            return 'title' === $namesValue || 'description' === $namesValue ||'keywords' === $namesValue;
+            return 'title' === $nameValue || 'description' === $nameValue ||'keywords' === $nameValue;
         });
 
         $actualMeta = $metaCrawler->extract('content', 'content');


### PR DESCRIPTION
was a little bit confused by sonatas example that i pushed all meta keys into

```
<meta names="key" ... />
```

instead of

```
<meta name="key" ... />
```

so i fixed it.
