### PR TITLE
$document -> $object in some use cases

### DIFF
--- a/EventListener/SeoContentListener.php
+++ b/EventListener/SeoContentListener.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
- * This listener takes care of documents which implements the SeoAwareInterface.
+ * This listener takes care of content objects which implements the SeoAwareInterface.
  *
  * In case of a match the listener calls a special presentation model to
  * prepare the SeoMetadata for putting it into sonatas Page Service.

--- a/Extractor/SeoDescriptionExtractor.php
+++ b/Extractor/SeoDescriptionExtractor.php
@@ -25,20 +25,20 @@ class SeoDescriptionExtractor implements SeoExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function supports($document)
+    public function supports($object)
     {
-        return $document instanceof SeoDescriptionReadInterface;
+        return $object instanceof SeoDescriptionReadInterface;
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param SeoDescriptionReadInterface $document
+     * @param SeoDescriptionReadInterface $object
      */
-    public function updateMetadata($document, SeoMetadataInterface $seoMetadata)
+    public function updateMetadata($object, SeoMetadataInterface $seoMetadata)
     {
         if (null === $seoMetadata->getMetaDescription() || '' === $seoMetadata->getMetaDescription()) {
-           $seoMetadata->setMetaDescription($document->getSeoDescription());
+           $seoMetadata->setMetaDescription($object->getSeoDescription());
         }
     }
 }

--- a/Extractor/SeoExtractorInterface.php
+++ b/Extractor/SeoExtractorInterface.php
@@ -28,11 +28,11 @@ interface SeoExtractorInterface
      * an interface or being instance of a specific class,
      * or introspection to see if a certain method exists.
      *
-     * @param object $document
+     * @param object $object
      *
-     * @return boolean whether this strategy supports $document
+     * @return boolean whether this strategy supports $object
      */
-    public function supports($document);
+    public function supports($object);
 
     /**
      * Update the metadata object with information from this document.
@@ -42,8 +42,8 @@ interface SeoExtractorInterface
      *
      * This method is should only be called if supports returned true.
      *
-     * @param object               $document
+     * @param object               $object
      * @param SeoMetadataInterface $seoMetadata
      */
-    public function updateMetadata($document, SeoMetadataInterface $seoMetadata);
+    public function updateMetadata($object, SeoMetadataInterface $seoMetadata);
 }

--- a/Extractor/SeoOriginalRouteExtractor.php
+++ b/Extractor/SeoOriginalRouteExtractor.php
@@ -33,19 +33,19 @@ class SeoOriginalRouteExtractor implements SeoExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function supports($document)
+    public function supports($object)
     {
-        return $document instanceof SeoOriginalRouteReadInterface;
+        return $object instanceof SeoOriginalRouteReadInterface;
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param SeoOriginalRouteReadInterface $document
+     * @param SeoOriginalRouteReadInterface $object
      */
-    public function updateMetadata($document, SeoMetadataInterface $seoMetadata)
+    public function updateMetadata($object, SeoMetadataInterface $seoMetadata)
     {
-        $route = $document->getSeoOriginalRoute();
+        $route = $object->getSeoOriginalRoute();
 
         try {
             $seoMetadata->setOriginalUrl($this->urlGenerator->generate($route));

--- a/Extractor/SeoOriginalUrlExtractor.php
+++ b/Extractor/SeoOriginalUrlExtractor.php
@@ -28,18 +28,18 @@ class SeoOriginalUrlExtractor implements SeoExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function supports($document)
+    public function supports($object)
     {
-        return $document instanceof SeoOriginalUrlReadInterface;
+        return $object instanceof SeoOriginalUrlReadInterface;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function updateMetadata($document, SeoMetadataInterface $seoMetadata)
+    public function updateMetadata($object, SeoMetadataInterface $seoMetadata)
     {
         if (null === $seoMetadata->getOriginalUrl() || '' === $seoMetadata->getOriginalUrl()) {
-            $seoMetadata->setOriginalUrl($document->getSeoOriginalUrl());
+            $seoMetadata->setOriginalUrl($object->getSeoOriginalUrl());
         }
     }
 }

--- a/Extractor/SeoTitleExtractor.php
+++ b/Extractor/SeoTitleExtractor.php
@@ -25,20 +25,20 @@ class SeoTitleExtractor implements SeoExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function supports($document)
+    public function supports($object)
     {
-        return $document instanceof SeoTitleReadInterface;
+        return $object instanceof SeoTitleReadInterface;
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param SeoTitleReadInterface $document
+     * @param SeoTitleReadInterface $object
      */
-    public function updateMetadata($document, SeoMetadataInterface $seoMetadata)
+    public function updateMetadata($object, SeoMetadataInterface $seoMetadata)
     {
         if (null === $seoMetadata->getTitle() || '' === $seoMetadata->getTitle()) {
-            $seoMetadata->setTitle($document->getSeoTitle());
+            $seoMetadata->setTitle($object->getSeoTitle());
         }
     }
 }

--- a/Extractor/TitleReadExtractor.php
+++ b/Extractor/TitleReadExtractor.php
@@ -24,18 +24,18 @@ class TitleReadExtractor implements SeoExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function supports($document)
+    public function supports($object)
     {
-        return method_exists($document, 'getTitle');
+        return method_exists($object, 'getTitle');
     }
 
     /**
      * {@inheritDoc}
      */
-    public function updateMetadata($document, SeoMetadataInterface $seoMetadata)
+    public function updateMetadata($object, SeoMetadataInterface $seoMetadata)
     {
         if (null === $seoMetadata->getTitle() || '' === $seoMetadata->getTitle()) {
-            $seoMetadata->setTitle($document->getTitle());
+            $seoMetadata->setTitle($object->getTitle());
         }
     }
 }

--- a/Model/SeoPresentation.php
+++ b/Model/SeoPresentation.php
@@ -117,22 +117,22 @@ class SeoPresentation implements SeoPresentationInterface
     }
 
     /**
-     * Gets the SeoMetadata based on the content document.
+     * Gets the SeoMetadata based on the object that contains the content.
      *
-     * @param object $contentDocument
+     * @param object $contentObject
      *
      * @return SeoMetadata
      */
-    private function getSeoMetadata($contentDocument)
+    private function getSeoMetadata($contentObject)
     {
-        $seoMetadata = $contentDocument instanceof SeoAwareInterface
-            ? clone $contentDocument->getSeoMetadata()
+        $seoMetadata = $contentObject instanceof SeoAwareInterface
+            ? clone $contentObject->getSeoMetadata()
             : new SeoMetadata()
         ;
 
         foreach ($this->strategies as $strategy) {
-            if ($strategy->supports($contentDocument)) {
-                $strategy->updateMetadata($contentDocument, $seoMetadata);
+            if ($strategy->supports($contentObject)) {
+                $strategy->updateMetadata($contentObject, $seoMetadata);
             }
         }
 
@@ -142,9 +142,9 @@ class SeoPresentation implements SeoPresentationInterface
     /**
      * {@inheritDoc}
      */
-    public function updateSeoPage($contentDocument)
+    public function updateSeoPage($contentObject)
     {
-        $seoMetadata = $this->getSeoMetadata($contentDocument);
+        $seoMetadata = $this->getSeoMetadata($contentObject);
         $translationDomain = $this->configValues->getTranslationDomain();
 
         if ($seoMetadata->getTitle()) {

--- a/Model/SeoPresentationInterface.php
+++ b/Model/SeoPresentationInterface.php
@@ -25,9 +25,9 @@ interface SeoPresentationInterface
     /**
      * Updates the Sonata SeoPage service with the data retrieved from the $contentDocument.
      *
-     * @param object $contentDocument The document to load data from.
+     * @param object $contentObject The document to load data from.
      */
-    public function updateSeoPage($contentDocument);
+    public function updateSeoPage($contentObject);
 
     /**
      * Returns the redirect response if the bundle is configured to redirect to


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #110 |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/438 needs to be refactored same way |

Just refactored some vars named `$document` to `$object` cause in that use cases all kinds of objects/entities/documents are useable.
