### PR TITLE
disable null values for seo metata

### DIFF
--- a/Model/SeoMetadata.php
+++ b/Model/SeoMetadata.php
@@ -136,10 +136,10 @@ class SeoMetadata implements SeoMetadataInterface
     public function toArray()
     {
         return array(
-            'title'                 => $this->getTitle(),
-            'metaDescription'       => $this->getMetaDescription(),
-            'metaKeywords'          => $this->getMetaKeywords(),
-            'originalUrl'           => $this->getOriginalUrl()
+            'title'                 => $this->getTitle() ?: '',
+            'metaDescription'       => $this->getMetaDescription() ?: '',
+            'metaKeywords'          => $this->getMetaKeywords() ?: '',
+            'originalUrl'           => $this->getOriginalUrl() ?: '',
         );
     }
 }

--- a/Tests/Unit/Model/SeoMetadataTest.php
+++ b/Tests/Unit/Model/SeoMetadataTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Model;
+use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata;
+
+/**
+ * @author Maximilian Berghoff <maximilian.berghoff@gmx.de>
+ */
+class SeoMetadataTest extends \PHPUnit_Framework_TestCase {
+
+
+    public function testNullValues()
+    {
+        $seoMetadata = new SeoMetadata();
+
+        $actual = $seoMetadata->toArray();
+        $expected = array(
+            'title'                 => '',
+            'metaDescription'       => '',
+            'metaKeywords'          => '',
+            'originalUrl'           => '',
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}
+ 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | not related |

As i don't know if is possible yet i implemented a secure condition, that no null values for `SeoMetadata` got into the persistence. (Problem: `SeoMetadata` is "serialized" to an array before update/persist -> array mapped as property with assoc)
