### PR TITLE
make form values not required in seo form type

### DIFF
--- a/Form/Type/SeoMetadataType.php
+++ b/Form/Type/SeoMetadataType.php
@@ -34,10 +34,10 @@ class SeoMetadataType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('title', 'text')
-            ->add('originalUrl', 'text')
-            ->add('metaDescription', 'textarea')
-            ->add('metaKeywords', 'textarea')
+            ->add('title', 'text', array('required' => false))
+            ->add('originalUrl', 'text', array('required' => false))
+            ->add('metaDescription', 'textarea', array('required' => false))
+            ->add('metaKeywords', 'textarea', array('required' => false))
         ;
     }
 


### PR DESCRIPTION
fix a little issue just have seen in sandbox. All Form values in SeoConfiguration tab had been required, what makes no sense.
