### PR TITLE
Fixed ExtraProperty form

### DIFF
--- a/Form/Type/ExtraPropertyType.php
+++ b/Form/Type/ExtraPropertyType.php
@@ -46,13 +46,12 @@ class ExtraPropertyType extends AbstractType
 
         // add a select field depending on the allowed types
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) {
-            $form = $event->getForm();
-            $choice = array();
+            $choices = array();
             foreach (ExtraProperty::getAllowedTypes() as $type) {
-                $choice[] = array('label' => $type, 'value' => $type);
+                $choices[$type] = $type;
             }
 
-            $form->add('type', 'collection', array('options' => array('choices' => $choice)));
+            $event->getForm()->add('type', 'choice', array('choices' => $choices));
         });
     }
 
@@ -63,9 +62,8 @@ class ExtraPropertyType extends AbstractType
     {
         $resolver->setDefaults(array(
             'label'        => false,
-            'allow_add'    => true,
-            'allow_delete' => true,
             'required'     => false,
+            'data_class'   => 'Symfony\Cmf\Bundle\SeoBundle\Model\ExtraProperty',
         ));
     }
 }

--- a/Form/Type/SeoMetadataType.php
+++ b/Form/Type/SeoMetadataType.php
@@ -15,6 +15,7 @@ namespace Symfony\Cmf\Bundle\SeoBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Cmf\Bundle\SeoBundle\Form\Type\ExtraPropertyType;
 
 /**
  * A form type for editing the SEO metadata.
@@ -38,7 +39,11 @@ class SeoMetadataType extends AbstractType
             ->add('originalUrl', 'text', array('required' => false))
             ->add('metaDescription', 'textarea', array('required' => false))
             ->add('metaKeywords', 'textarea', array('required' => false))
-            ->add('extraProperties', 'seo_extra_property', array('data_class' => null))
+            ->add('extraProperties', 'collection', array(
+                'type' => new ExtraPropertyType(),
+                'allow_add'    => true,
+                'allow_delete' => true,
+            ))
         ;
     }
 

--- a/Model/ExtraProperty.php
+++ b/Model/ExtraProperty.php
@@ -53,11 +53,18 @@ class ExtraProperty
      */
     private static $allowedTypes = array('name', 'property', 'http-equiv');
 
-    public function __construct($key, $value, $type)
+    public function __construct($key = null, $value = null, $type = null)
     {
-        $this->key = $key;
-        $this->value = $value;
+        $this->setKey($key);
+        $this->setValue($value);
 
+        if (null !== $type) {
+            $this->setType($type);
+        }
+    }
+
+    public function setType($type)
+    {
         if (!in_array($type, self::$allowedTypes)) {
             throw new InvalidArgumentException(sprintf('Type "%s" is not allowed for meta tags, use one of: %s', $type, implode(', ', self::$allowedTypes)));
         }

--- a/SeoMetadata.php
+++ b/SeoMetadata.php
@@ -69,13 +69,11 @@ class SeoMetadata implements SeoMetadataInterface
         $keys = array('title', 'metaDescription', 'metaKeywords', 'originalUrl');
         $metadata = new self();
         foreach ($data as $key => $value) {
-            $metadata->createProperty($metadata, $key, $value);
-
-            if (!in_array($key, $keys)) {
-                continue;
+            if (in_array($key, $keys)) {
+                $metadata->{'set'.ucfirst($key)}($value);
+            } else {
+                $metadata->createProperty($metadata, $key, $value);
             }
-
-            $metadata->{'set'.ucfirst($key)}($value);
         }
 
         return $metadata;
@@ -228,11 +226,9 @@ class SeoMetadata implements SeoMetadataInterface
      */
     private function getExtraPropertiesArray()
     {
-        /** @var ExtraProperty[] $properties */
-        $properties = $this->extraProperties->toArray();
         $result = array();
 
-        foreach ($properties as $property) {
+        foreach ($this->extraProperties as $property) {
             $result[$property->getType().'_'.$property->getKey()] = $property->getValue();
         }
 


### PR DESCRIPTION
I had to revert back to make the ExtraProperty class fully mutable (this
way the form can work with it and I don't have to create a custom
normalizer), so @ElectricMaxxx you were correct on this one :P

There were also some problems in the fromArray method of the metadata.

Fixes #148
