### PR TITLE
have admin extension handle the locale

### DIFF
--- a/Admin/Extension/SeoContentAdminExtension.php
+++ b/Admin/Extension/SeoContentAdminExtension.php
@@ -12,17 +12,14 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 /**
  * This AdminExtension will serve the bundle's own form type
  * for configuring seo metadata.
- *
- * To get this admin extension, you need to enable SonataAdminBundle support by
- * setting `cmf_seo.persistence.phpcr.use_sonata_admin` in the configuration to
- * `true` (it defaults to `auto`, which means it'll use it when the
- * SonataAdminBundle is registered). You will need your own Admin class with its
- * mapping and let the content implement the SeoAwareInterface.
  *
  * @author Maximilian Berghoff <maximilian.berghoff@gmx.de>
  */
@@ -35,5 +32,33 @@ class SeoContentAdminExtension extends AdminExtension
                 ->add('seoMetadata', 'seo_metadata', array('label' => false))
             ->end()
         ;
+    }
+
+    public function preUpdate(AdminInterface $admin, $seoAware)
+    {
+        $this->propagateLocale($seoAware);
+    }
+
+    public function prePersist(AdminInterface $admin, $seoAware)
+    {
+        $this->propagateLocale($seoAware);
+    }
+
+    /**
+     * The seo metadata that was edited embedded has the same locale as the
+     * containing document.
+     *
+     * @param SeoAwareInterface $seoAware
+     */
+    private function propagateLocale(SeoAwareInterface $seoAware)
+    {
+        if (!$seoAware instanceof TranslatableInterface) {
+            return;
+        }
+        $seoMetadata = $seoAware->getSeoMetadata();
+        if (!$seoMetadata instanceof TranslatableInterface) {
+            return;
+        }
+        $seoMetadata->setLocale($seoAware->getLocale());
     }
 }

--- a/Doctrine/Phpcr/SeoMetadata.php
+++ b/Doctrine/Phpcr/SeoMetadata.php
@@ -12,12 +12,13 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr;
 
 use Doctrine\ODM\PHPCR\HierarchyInterface;
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
 use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata as SeoMetadataModel;
 
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
  */
-class SeoMetadata extends SeoMetadataModel implements HierarchyInterface
+class SeoMetadata extends SeoMetadataModel implements HierarchyInterface, TranslatableInterface
 {
     /**
      * @var string

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "burgov/key-value-form-bundle": "1.0.*"
     },
     "suggest": {
+        "symfony-cmf/core-bundle": "When using the provided PHPCR-ODM document",
         "sonata-project/doctrine-phpcr-admin-bundle": "To provide an admin extension for the seo metadata",
         "doctrine/phpcr-bundle": "To persist the metadata in PHPCR ODM documents",
         "doctrine/doctrine-bundle": "To persist the metadata in ORM entities",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | travis |
| Fixed tickets | #161 |
| License | MIT |
| Doc PR | TODO |

So yes, this re-introduces the optional dependency with CoreBundle. But that is ok its just for the phpcr-odm document and the dependency on phpcr-odm itself is also optional.
