### PR TITLE
fix version constraint to doctrine/phpcr-odm package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.3",
-        "sonata-project/seo-bundle": "1.1.*@dev",
+        "sonata-project/seo-bundle": "1.1.*",
         "doctrine/collections": "1.*"
     },
     "require-dev": {
         "symfony-cmf/testing": "dev-master",
-        "doctrine/phpcr-bundle": "1.1.*@dev",
-        "doctrine/phpcr-odm": "1.1.*@dev",
-        "doctrine/orm": "2.4.*@dev",
-        "sonata-project/doctrine-phpcr-admin-bundle": "1.1.*@dev",
-        "symfony-cmf/routing-bundle": "1.2.*@dev",
-        "symfony-cmf/core-bundle": "1.1.*@dev",
+        "doctrine/phpcr-bundle": "1.1.*",
+        "doctrine/phpcr-odm": ">=1.1.0-RC2",
+        "doctrine/orm": "2.4.*",
+        "sonata-project/doctrine-phpcr-admin-bundle": "1.1.*",
+        "symfony-cmf/routing-bundle": "1.2.*",
+        "symfony-cmf/core-bundle": "1.1.*",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "matthiasnoback/symfony-config-test": "0.*",
         "burgov/key-value-form-bundle": "1.0.*"
@@ -35,7 +35,7 @@
         "sonata-project/doctrine-phpcr-admin-bundle": "To provide an admin extension for the seo metadata",
         "doctrine/phpcr-bundle": "To persist the metadata in PHPCR ODM documents",
         "doctrine/doctrine-bundle": "To persist the metadata in ORM entities",
-        "doctrine/orm": "2.4.*@dev",
+        "doctrine/orm": "2.4.*",
         "burgov/key-value-form-bundle": "To edit the seo metadata 'extra' fields"
     },
     "autoload":{


### PR DESCRIPTION
The setFallbackLocales() method in the locale chooser of the doctrine/phpcr-odm package was first added on March 1st. Thus, 1.1.0-RC1 or higher of doctrine/phpcr-odm is required.

Unfortunately, this proposed change doesn't solve the issue. As you can see [here](https://travis-ci.org/xabbuh/SeoBundle/jobs/27011434), Composer isn't able to resolve the dependencies.
