### PR TITLE
implementing alternate languages for content documents

### DIFF
--- a/AlternateLocaleProviderInterface.php
+++ b/AlternateLocaleProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle;
+
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocaleCollection;
+
+/**
+ * An interface for providing alternate locale urls.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+interface AlternateLocaleProviderInterface
+{
+    /**
+     * Creates a collection of AlternateLocales for one content object.
+     *
+     * @param object                        $content
+     *
+     * @return AlternateLocaleCollection
+     */
+    public function createForContent($content);
+
+    /**
+     * Creates a collection of AlternateLocales for many content object.
+     *
+     * @param array|object[]                $contents
+     *
+     * @return AlternateLocaleCollection[]
+     */
+    public function createForContents(array $contents);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.1.0-RC1
 ---------
 
+* **2014-02-08**: Implement alternate locale support and its configuration
 * **2014-06-06**: Updated to PSR-4 autoloading
 
 1.0.0

--- a/CmfSeoBundle.php
+++ b/CmfSeoBundle.php
@@ -15,7 +15,6 @@ use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\DoctrinePhpcrMappin
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler\RegisterExtractorsPass;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -72,6 +72,13 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('form_group')->defaultValue('form.group_seo')->end()
                     ->end()
                 ->end()
+                ->arrayNode('alternate_locale')
+                    ->addDefaultsIfNotSet()
+                    ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('provider_id')->defaultNull()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/Doctrine/Phpcr/AlternateLocaleProvider.php
+++ b/Doctrine/Phpcr/AlternateLocaleProvider.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
+use Symfony\Cmf\Bundle\SeoBundle\AlternateLocaleProviderInterface;
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocale;
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocaleCollection;
+use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * This provider looks at the actual locales of a
+ * PHPCR-ODM document to determine what locales really exist.
+ *
+ * Note: If it would just look at the route referrers,
+ * the alternates would contain the translated route for untranslated content.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class AlternateLocaleProvider implements AlternateLocaleProviderInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var ManagerRegistry
+     */
+    private $managerRegistry;
+
+    /**
+     * @param ManagerRegistry       $managerRegistry
+     * @param UrlGeneratorInterface $urlGenerator
+     */
+    public function __construct(ManagerRegistry $managerRegistry, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * Creates a collection of AlternateLocales for one content object.
+     *
+     * @param object $content
+     *
+     * @return AlternateLocaleCollection
+     */
+    public function createForContent($content)
+    {
+        $alternateLocaleCollection = new AlternateLocaleCollection();
+        if (!$content instanceof TranslatableInterface || !$content instanceof RouteReferrersReadInterface) {
+            return $alternateLocaleCollection;
+        }
+
+        $documentManager = $this->getDocumentManagerForClass(get_class($content));
+        if (null === $documentManager) {
+            return $alternateLocaleCollection;
+        }
+
+        $alternateLocales = $documentManager->getLocalesFor($content);
+        $currentLocale = $content->getLocale();
+        foreach ($alternateLocales as $locale) {
+            if ($locale === $currentLocale) {
+                continue;
+            }
+
+            $alternateLocaleCollection->add(
+                new AlternateLocale(
+                    $this->urlGenerator->generate($content, array('_locale' => $locale), true),
+                    $locale
+                )
+            );
+        }
+
+        return $alternateLocaleCollection;
+    }
+
+    /**
+     * Creates a collection of AlternateLocales for many content object.
+     *
+     * @param array|object[] $contents
+     *
+     * @return AlternateLocaleCollection[]
+     */
+    public function createForContents(array $contents)
+    {
+        $result = array();
+        foreach ($contents as $content) {
+            $result[] = $this->createForContent($content);
+        }
+
+        return $result;
+    }
+
+    /**
+     * When the registry was set, this method figure out
+     * the document manager of a given class.
+     *
+     * @param $class
+     *
+     * @return DocumentManager|null|object
+     */
+    private function getDocumentManagerForClass($class)
+    {
+        return $this->managerRegistry->getManagerForClass($class);
+    }
+}

--- a/Model/AlternateLocale.php
+++ b/Model/AlternateLocale.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Model;
+
+/**
+ * Value object for properties of an alternate locale.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class AlternateLocale
+{
+    const REL = 'alternate';
+
+    /**
+     * @var string The absolute url for that locale.
+     */
+    public $href;
+
+    /**
+     * @var string The locale/language in the following formats: de, de-DE
+     */
+    public $hrefLocale;
+
+    public function __construct($href, $hrefLocale)
+    {
+
+        $this->href = $href;
+        $this->hrefLocale = $hrefLocale;
+    }
+}

--- a/Model/AlternateLocaleCollection.php
+++ b/Model/AlternateLocaleCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * Collection for alternate locales.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class AlternateLocaleCollection extends ArrayCollection
+{
+
+}

--- a/Resources/config/phpcr-alternate-locale.xml
+++ b/Resources/config/phpcr-alternate-locale.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_seo.alternate_locale.provider_phpcr.class">Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\AlternateLocaleProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="cmf_seo.alternate_locale.provider_phpcr" class="%cmf_seo.alternate_locale.provider_phpcr.class%">
+            <argument type="service" id="doctrine_phpcr" />
+            <argument type="service" id="router" />
+        </service>
+    </services>
+
+</container>

--- a/SeoPresentation.php
+++ b/SeoPresentation.php
@@ -12,9 +12,11 @@
 namespace Symfony\Cmf\Bundle\SeoBundle;
 
 use Sonata\SeoBundle\Seo\SeoPage;
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocaleCollection;
 use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata;
 use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadataInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface;
 use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\ConfigValues;
@@ -308,5 +310,18 @@ class SeoPresentation implements SeoPresentationInterface
         $metadata->setExtraHttp($contentSeoMetadata->getExtraHttp()?:array());
 
         return $metadata;
+    }
+
+    /**
+     * {inheritDoc}
+     */
+    public function updateAlternateLocales(AlternateLocaleCollection $collection)
+    {
+        foreach ($collection as $alternateLocale) {
+            $this->sonataPage->addLangAlternate(
+                $alternateLocale->href,
+                $alternateLocale->hrefLocale
+            );
+        }
     }
 }

--- a/SeoPresentationInterface.php
+++ b/SeoPresentationInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\SeoBundle;
 
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocaleCollection;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -36,4 +37,11 @@ interface SeoPresentationInterface
      * @return boolean|RedirectResponse
      */
     public function getRedirectResponse();
+
+    /**
+     * Updates alternate locale information on the Sonata SeoPage service.
+     *
+     * @param AlternateLocaleCollection $collection
+     */
+    public function updateAlternateLocales(AlternateLocaleCollection $collection);
 }

--- a/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use PHPCR\Util\NodeHelper;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
 use Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SeoMetadata;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\AlternateLocaleContent;
 use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SeoAwareContent;
 use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\ContentWithExtractors;
 
@@ -88,6 +89,42 @@ class LoadContentData implements FixtureInterface
         $route->setDefault('_controller', 'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Controller\TestController::indexAction');
 
         $manager->persist($route);
+
+        $alternateLocaleContent = new AlternateLocaleContent();
+        $alternateLocaleContent->setName('alternate-locale-content');
+        $alternateLocaleContent->setTitle('Alternate locale content');
+        $alternateLocaleContent->setBody('Body of some alternate locate content');
+        $alternateLocaleContent->setParentDocument($contentRoot);
+        $manager->persist($alternateLocaleContent);
+        $manager->bindTranslation($alternateLocaleContent, 'en');
+
+        // creating the locale base routes as generic for now
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test/routes/de');
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test/routes/en');
+
+        $deRoute = $manager->find(null, '/test/routes/de');
+        $enRoute = $manager->find(null, '/test/routes/en');
+
+        $alternateLocaleRoute = new Route();
+        $alternateLocaleRoute->setPosition($enRoute, 'alternate-locale-content');
+        $alternateLocaleRoute->setContent($alternateLocaleContent);
+        $alternateLocaleRoute->setDefault(
+            '_controller',
+            'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Controller\TestController::indexAction'
+        );
+        $manager->persist($alternateLocaleRoute);
+
+        $alternateLocaleContent->setTitle('Alternative Sprachen');
+        $manager->bindTranslation($alternateLocaleContent, 'de');
+
+        $alternateLocaleRoute = new Route();
+        $alternateLocaleRoute->setPosition($deRoute, 'alternate-locale-content');
+        $alternateLocaleRoute->setContent($alternateLocaleContent);
+        $alternateLocaleRoute->setDefault(
+            '_controller',
+            'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Controller\TestController::indexAction'
+        );
+        $manager->persist($alternateLocaleRoute);
 
         $manager->flush();
     }

--- a/Tests/Resources/Document/AlternateLocaleContent.php
+++ b/Tests/Resources/Document/AlternateLocaleContent.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
+use Symfony\Cmf\Component\Routing\RouteReferrersInterface;
+use Symfony\Component\Routing\Route;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * @PHPCRODM\Document(translator="attribute")
+ */
+class AlternateLocaleContent extends ContentBase implements
+    RouteReferrersInterface,
+    TranslatableInterface
+{
+    /**
+     * @var string
+     *
+     * @PHPCRODM\Locale
+     */
+    protected $locale;
+
+    /**
+     * @var string
+     *
+     * @PHPCRODM\String(translated=true)
+     */
+    protected $title;
+
+    /**
+     * @var ArrayCollection|Route[]
+     *
+     * @PHPCRODM\Referrers(
+     *  referringDocument="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route",
+     *  referencedBy="content"
+     * )
+     */
+    protected $routes;
+
+    public function __construct()
+    {
+        $this->routes = new ArrayCollection();
+    }
+    /**
+     * Add a route to the collection.
+     *
+     * @param Route $route
+     */
+    public function addRoute($route)
+    {
+        $this->routes->add($route);
+    }
+
+    /**
+     * Remove a route from the collection.
+     *
+     * @param Route $route
+     */
+    public function removeRoute($route)
+    {
+        $this->routes->removeElement($route);
+    }
+
+    /**
+     * Get the routes that point to this content.
+     *
+     * @return Route[] Route instances that point to this content
+     */
+    public function getRoutes()
+    {
+        return $this->routes;
+    }
+
+    /**
+     * @return string|boolean The locale of this model or false if
+     *                        translations are disabled in this project.
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @param string|boolean $locale The local for this model, or false if
+     *                               translations are disabled in this project.
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+}

--- a/Tests/Resources/app/config/cmf_seo.phpcr.yml
+++ b/Tests/Resources/app/config/cmf_seo.phpcr.yml
@@ -1,9 +1,11 @@
 cmf_seo:
     persistence: { phpcr: true }
+    alternate_locale: ~
     sonata_admin_extension: true
 
 cmf_routing:
     dynamic:
+        locales: [de, en]
         enabled: true
         persistence:
             phpcr:

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -56,6 +56,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled' => 'auto',
                 'form_group' => 'form.group_seo',
             ),
+            'alternate_locale' => array(
+                'enabled'  => false,
+                'provider_id' => null,
+            ),
         );
 
         $sources = array_map(function ($path) {

--- a/Tests/WebTest/SeoFrontendTest.php
+++ b/Tests/WebTest/SeoFrontendTest.php
@@ -140,4 +140,27 @@ class SeoFrontendTest extends BaseTestCase
             array('http-equiv', 'Content-Type', 'text/html; charset=utf-8'),
         );
     }
+
+    public function testAlternateLanguages()
+    {
+        $crawler = $this->client->request('GET', '/en/alternate-locale-content');
+        $res = $this->client->getResponse();
+
+        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertCount(1, $crawler->filter('html:contains("Alternate locale content")'));
+
+        $linkCrawler = $crawler->filter('head > link');
+        $expectedArray = array(array('alternate', 'http://localhost/de/alternate-locale-content', 'de'));
+        $this->assertEquals($expectedArray, $linkCrawler->extract(array('rel', 'href', 'hreflang')));
+
+        $crawler = $this->client->request('GET', '/de/alternate-locale-content');
+        $res = $this->client->getResponse();
+
+        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertCount(1, $crawler->filter('html:contains("Alternative Sprachen")'));
+
+        $linkCrawler = $crawler->filter('head > link');
+        $expectedArray = array(array('alternate', 'http://localhost/en/alternate-locale-content', 'en'));
+        $this->assertEquals($expectedArray, $linkCrawler->extract(array('rel', 'href', 'hreflang')));
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "suggest": {
         "symfony-cmf/core-bundle": "When using the provided PHPCR-ODM document",
+        "symfony-cmf/routing-bundle": "To make use of the alternate locale provider.",
         "sonata-project/doctrine-phpcr-admin-bundle": "To provide an admin extension for the seo metadata",
         "doctrine/phpcr-bundle": "To persist the metadata in PHPCR ODM documents",
         "doctrine/doctrine-bundle": "To persist the metadata in ORM entities",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [no] |
| Fixed tickets | [#166] |
| License | MIT |
| Doc PR | not yet |

I started to implement that feature. Thought we should take care for the existence of the `ManagerRegistry` and when it exists the `SeoPresentation::setAlternateLocales()` method will figure out urls (by `UrlGenerator`) and pass that information to sonatas `PageService`. By doing it that way the user just needs to add the right TwigHelper `{{ sonata_seo_lang_alternates() }}` to see the result. Same procedure as all other metadata comes into the template.

Todo:
- [x] implement logic in `ContentListener`
- [x] add registry by compiler pass
- [x] add method in `SeoPresentation` to compute and set the alternate lang values to `PageService`
- [ ] tests for unit and frontend
- [ ] take care on current route
- [ ] fix strange url problem
