### PR TITLE
create custom exception/error handling mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* **2014-10-04**: Custom exception controller for error handling
+
 1.1.0-RC3
 ---------
 

--- a/CmfSeoBundle.php
+++ b/CmfSeoBundle.php
@@ -18,12 +18,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler\RegisterExtractorsPass;
+use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler\RegisterSuggestionProviderPass;
 
 class CmfSeoBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new RegisterExtractorsPass());
+        $container->addCompilerPass(new RegisterSuggestionProviderPass());
 
         $this->buildPhpcrCompilerPass($container);
         $this->buildOrmCompilerPass($container);

--- a/Controller/SuggestionProviderController.php
+++ b/Controller/SuggestionProviderController.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Controller;
+
+use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
+use Symfony\Cmf\Bundle\SeoBundle\SuggestionProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+
+/**
+ * This presentation model enriches the the values to render the
+ * error pages by the help of so called SuggestionProviders.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SuggestionProviderController extends ExceptionController
+{
+    /**
+     * Chain of suggestion providers.
+     *
+     * @var array|SuggestionProviderInterface[]
+     */
+    protected $suggestionProviders = array();
+
+    /**
+     * @param Request              $request
+     * @param FlattenException     $exception
+     * @param DebugLoggerInterface $logger
+     * @param string               $_format
+     * @return Response
+     */
+    public function showAction(
+        Request $request,
+        FlattenException $exception,
+        DebugLoggerInterface $logger = null,
+        $_format = 'html'
+    ) {
+        $code = $exception->getStatusCode();
+
+        if (404 !== $code) {
+            return parent::showAction($request, $exception, $logger, $_format);
+        }
+
+        $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
+        $groupedSuggestions = array();
+
+        foreach ($this->suggestionProviders as $item) {
+            $suggestions = $item['provider']->create($request);
+            $groupedSuggestions[$item['group']] = isset($groupedSuggestions[$item['group']])
+                ? array_merge($groupedSuggestions[$item['group']], $suggestions)
+                : $suggestions;
+        }
+
+        return new Response(
+            $this->twig->render(
+                $this->findTemplate($request, $_format, $code, $this->debug),
+                array(
+                    'status_code'    => $code,
+                    'status_text'    => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
+                    'exception'      => $exception,
+                    'logger'         => $logger,
+                    'currentContent' => $currentContent,
+                    'best_matches'   => $groupedSuggestions,
+                )
+            ),
+            $code
+        );
+    }
+
+    /**
+     * @param SuggestionProviderInterface $matcher
+     * @param string                      $group
+     */
+    public function addSuggestionProvider(SuggestionProviderInterface $matcher, $group)
+    {
+        $this->suggestionProviders[] = array('provider' => $matcher, 'group' => $group);
+    }
+}

--- a/DependencyInjection/CmfSeoExtension.php
+++ b/DependencyInjection/CmfSeoExtension.php
@@ -64,6 +64,8 @@ class CmfSeoExtension extends Extension
             $sonataBundles[] = 'SonataDoctrinePHPCRAdminBundle';
 
             $this->loadPhpcr($config['persistence']['phpcr'], $loader, $container);
+
+            $loader->load('matcher_phpcr.xml');
         }
 
         if ($this->isConfigEnabled($container, $config['persistence']['orm'])) {
@@ -82,6 +84,9 @@ class CmfSeoExtension extends Extension
         if ($this->isConfigEnabled($container, $config['alternate_locale'])) {
             $this->loadAlternateLocaleProvider($config['alternate_locale'], $container);
         }
+
+        $errorConfig = isset($config['error']) ? $config['error'] : array();
+        $this->loadErrorHandling($errorConfig, $container);
     }
 
     /**
@@ -143,7 +148,7 @@ class CmfSeoExtension extends Extension
     }
 
     /**
-        * {@inheritDoc}
+     * {@inheritDoc}
      */
     public function getXsdValidationBasePath()
     {
@@ -191,6 +196,24 @@ class CmfSeoExtension extends Extension
                     array($container->getDefinition($alternateLocaleProvider))
                 )
             ;
+        }
+    }
+
+    /**
+     * Enabled suggestion providers will stay in the container only.
+     *
+     * The providers are activated only, when phpcr is chosen as persistence.
+     *
+     * @param $config
+     * @param ContainerBuilder $container
+     */
+    private function loadErrorHandling($config, ContainerBuilder $container)
+    {
+        foreach (array('parent', 'sibling') as $group) {
+            $remove = isset($config['enable_'.$group.'_provider']) && !$config['enable_'.$group.'_provider'] ? true : false;
+            if ($container->has('cmf_seo.error.suggestion_provider.'.$group) && $remove) {
+                $container->removeDefinition('cmf_seo.error.suggestion_provider.'.$group);
+            }
         }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,6 +79,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('provider_id')->defaultNull()->end()
                     ->end()
                 ->end()
+                ->arrayNode('error')
+                    ->children()
+                        ->scalarNode('enable_parent_provider')->defaultValue(false)->end()
+                        ->scalarNode('enable_sibling_provider')->defaultValue(false)->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/Doctrine/Phpcr/BaseSuggestionProvider.php
+++ b/Doctrine/Phpcr/BaseSuggestionProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Bundle\SeoBundle\SuggestionProviderInterface;
+
+/**
+ * Abstract suggestion provider for those who needs make use of base
+ * phpcr-odm classes.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+abstract class BaseSuggestionProvider implements SuggestionProviderInterface
+{
+    /**
+     * @var ManagerRegistry
+     */
+    protected $managerRegistry;
+
+    /**
+     * By concatenating the routeBasePath and the url
+     * we will get the absolute path a route document
+     * should be persisted with.
+     *
+     * @var string
+     */
+    protected $routeBasePath;
+
+    /**
+     * @param ManagerRegistry $managerRegistry
+     * @param $routeBasePath
+     */
+    public function __construct(ManagerRegistry $managerRegistry, $routeBasePath)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->routeBasePath = $routeBasePath;
+    }
+
+    /**
+     * @param string                $class
+     *
+     * @return null|DocumentManager
+     */
+    public function getManagerForClass($class)
+    {
+        return $this->managerRegistry->getManagerForClass($class);
+    }
+}

--- a/Doctrine/Phpcr/ParentSuggestionProvider.php
+++ b/Doctrine/Phpcr/ParentSuggestionProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr;
+
+use PHPCR\Util\PathHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+/**
+ * This provider looks for the direct parent of the requested URL.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class ParentSuggestionProvider extends BaseSuggestionProvider
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function create(Request $request)
+    {
+        $routes = array();
+        $manager = $this->getManagerForClass('Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route');
+        $parentPath = PathHelper::getParentPath($this->routeBasePath.$request->getPathInfo());
+
+        $parentRoute = $manager->find(null, $parentPath);
+        if (!$parentRoute) {
+            return $routes;
+        }
+
+        if ($parentRoute instanceof Route) {
+            $routes[$parentRoute->getName()] = $parentRoute;
+        }
+
+        return $routes;
+    }
+}

--- a/Doctrine/Phpcr/SiblingSuggestionProvider.php
+++ b/Doctrine/Phpcr/SiblingSuggestionProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr;
+
+use PHPCR\Util\PathHelper;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * This provider looks for all ancestors of a requested URL.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SiblingSuggestionProvider extends BaseSuggestionProvider
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function create(Request $request)
+    {
+        $manager = $this->getManagerForClass('Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route');
+        $parentPath = PathHelper::getParentPath($this->routeBasePath.$request->getPathInfo());
+        $parentRoute = $manager->find(null, $parentPath);
+
+        if (!$parentRoute) {
+            return array();
+        }
+
+        $routes = array();
+        $childRoutes = $manager->getChildren($parentRoute);
+
+        foreach ($childRoutes->toArray() as $childRoute) {
+            $routes[$childRoute->getName()] = $childRoute;
+        }
+
+        return $routes;
+    }
+}

--- a/Resources/config/matcher_phpcr.xml
+++ b/Resources/config/matcher_phpcr.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_seo.error.suggestion_provider.parent.class">Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\ParentSuggestionProvider</parameter>
+        <parameter key="cmf_seo.error.suggestion_provider.sibling.class">Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SiblingSuggestionProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="cmf_seo.error.suggestion_provider.parent" class="%cmf_seo.error.suggestion_provider.parent.class%">
+            <argument type="service" id="doctrine_phpcr" />
+            <argument>%cmf_routing.dynamic.persistence.phpcr.route_basepath%</argument>
+            <tag name="cmf_seo.suggestion_provider" group="parent" />
+        </service>
+        <service id="cmf_seo.error.suggestion_provider.sibling" class="%cmf_seo.error.suggestion_provider.sibling.class%">
+            <argument type="service" id="doctrine_phpcr" />
+            <argument>%cmf_routing.dynamic.persistence.phpcr.route_basepath%</argument>
+            <tag name="cmf_seo.suggestion_provider" group="sibling" />
+        </service>
+
+    </services>
+
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" ?>
 
-<container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+<container
+        xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
         <parameter key="cmf_seo.config_values.class">Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\ConfigValues</parameter>
@@ -11,6 +12,7 @@
         <parameter key="cmf_seo.cache.file.class">Symfony\Cmf\Bundle\SeoBundle\Cache\FileCache</parameter>
         <parameter key="cmf_seo.presentation.class">Symfony\Cmf\Bundle\SeoBundle\SeoPresentation</parameter>
         <parameter key="cmf_seo.event_listener.seo_content.class">Symfony\Cmf\Bundle\SeoBundle\EventListener\ContentListener</parameter>
+        <parameter key="cmf_seo.error.suggestion_provider.controller.class">Symfony\Cmf\Bundle\SeoBundle\Controller\SuggestionProviderController</parameter>
 
     </parameters>
 
@@ -47,6 +49,11 @@
             <argument type="service" id="cmf_seo.presentation"/>
             <argument>%cmf_seo.content_key%</argument>
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest"/>
+        </service>
+
+        <service id="cmf_seo.error.suggestion_provider.controller" class="%cmf_seo.error.suggestion_provider.controller.class%">
+            <argument type="service" id="twig" />
+            <argument>%kernel.debug%</argument>
         </service>
     </services>
 

--- a/SuggestionProviderInterface.php
+++ b/SuggestionProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Symfony\Cmf\Bundle\SeoBundle;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Interface for all suggestion providers.
+ *
+ * Those providers are responsible to create a list of suggestions (routes)
+ * for pages to visit instead of a blank 404 page.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+interface SuggestionProviderInterface
+{
+    /**
+     * Based on the current request this method creates a list
+     * of suggestions as an array of routes.
+     *
+     * @param Request $request
+     *
+     * @return array|Route[]
+     */
+    public function create(Request $request);
+}

--- a/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
@@ -126,6 +126,26 @@ class LoadContentData implements FixtureInterface
         );
         $manager->persist($alternateLocaleRoute);
 
+        # create content in a deeper structure
+        $content = new SeoAwareContent();
+        $content->setName('content-deeper');
+        $content->setTitle('Content deeper');
+        $content->setBody('Content deeper Body');
+        $content->setParentDocument($contentRoot);
+
+        $manager->persist($content);
+
+        $route = new Route();
+        $route->setPosition(
+            $manager->find(null, '/test/routes/content/content-1'),
+            'content-deeper'
+        );
+        $route->setContent($content);
+        $route->setDefault('_controller', 'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Controller\TestController::indexAction');
+
+        $manager->persist($route);
+
         $manager->flush();
+
     }
 }

--- a/Tests/Resources/app/Resources/TwigBundle/views/Exception/exception_full.html.twig
+++ b/Tests/Resources/app/Resources/TwigBundle/views/Exception/exception_full.html.twig
@@ -1,0 +1,14 @@
+<h1>Exception-Test</h1>
+
+<div>
+    <strong>{{ status_code }}</strong> {{ status_text }} - {{ exception.class|abbr_class }}
+</div>
+<div>
+    <ul>
+        {% for group, matchs in best_matches %}
+                {% for match in matchs %}
+                    <li>{{ group }} - {{ match.name }}</li>
+                {% endfor %}
+        {% endfor %}
+    </ul>
+</div>

--- a/Tests/Resources/app/config/cmf_seo.yml
+++ b/Tests/Resources/app/config/cmf_seo.yml
@@ -11,9 +11,15 @@ cmf_seo:
     title: "Default | %%content_title%%"
     description: "Default description. %%content_description%%"
     original_route_pattern: canonical
+    error:
+        enable_parent_provider: true
+        enable_sibling_provider: true
 
 cmf_routing:
     chain:
         routers_by_id:
             cmf_routing.dynamic_router: 20
             router.default: 100
+
+twig:
+    exception_controller: cmf_seo.error.suggestion_provider.controller:showAction

--- a/Tests/Unit/DependencyInjection/CmfSeoExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfSeoExtensionTest.php
@@ -30,6 +30,9 @@ class CmfSeoExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('cmf_seo.translation_domain', 'messages');
         $this->assertContainerBuilderHasParameter('cmf_seo.original_route_pattern', 'canonical');
         $this->assertContainerBuilderHasParameter('cmf_seo.content_key', 'contentDocument');
+        $this->assertContainerBuilderHasService('cmf_seo.error.suggestion_provider.controller');
+        $this->assertContainerBuilderNotHasService('cmf_seo.error.suggestion_provider.parent');
+        $this->assertContainerBuilderNotHasService('cmf_seo.error.suggestion_provider.sibling');
     }
 
     public function testPersistencePHPCR()
@@ -159,5 +162,34 @@ class CmfSeoExtensionTest extends AbstractExtensionTestCase
                 'phpcr' => true,
             )
         ));
+    }
+    public function testErrorHandlingPHPCR()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            array(
+                'CmfRoutingBundle' => true,
+            )
+        );
+        $this->load(array(
+            'persistence'   => array(
+                'phpcr' => true,
+            ),
+            'error' => array(
+                'enable_parent_provider' => true,
+                'enable_sibling_provider' => true,
+            )
+        ));
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'cmf_seo.error.suggestion_provider.sibling',
+            'cmf_seo.suggestion_provider',
+            array('group' => 'sibling')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'cmf_seo.error.suggestion_provider.parent',
+            'cmf_seo.suggestion_provider',
+            array('group' => 'parent')
+        );
     }
 }

--- a/Tests/Unit/DependencyInjection/Compiler/RegisterSuggestionProviderPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/RegisterSuggestionProviderPassTest.php
@@ -1,0 +1,70 @@
+<?php
+
+
+namespace Symfony\Cmf\SeoBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler\RegisterSuggestionProviderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class RegisterSuggestionProviderPassTest extends AbstractCompilerPassTestCase
+{
+
+    /**
+     * Register the compiler pass under test, just like you would do inside a bundle's load()
+     * method:
+     *
+     *   $container->addCompilerPass(new MyCompilerPass());
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RegisterSuggestionProviderPass());
+    }
+
+    public function testRegistersServicesWithMatcherTag()
+    {
+        $nonMatcherService = new Definition();
+        $this->setDefinition('some_service', $nonMatcherService);
+
+        $matcherServiceWithGroup = new Definition();
+        $matcherServiceWithGroup->addTag('cmf_seo.suggestion_provider', array('group' => 'some-group'));
+        $this->setDefinition('matcher.with_group', $matcherServiceWithGroup);
+
+        $matcherPresentationService = new Definition();
+        $this->setDefinition('cmf_seo.error.suggestion_provider.controller', $matcherPresentationService);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'cmf_seo.error.suggestion_provider.controller',
+            'addSuggestionProvider',
+            array(new Reference('matcher.with_group'), 'some-group')
+        );
+    }
+
+    public function testRegistersServicesWithMatcherTagWithoutGroup()
+    {
+        $nonMatcherService = new Definition();
+        $this->setDefinition('some_service', $nonMatcherService);
+
+        $matcherServiceWithOutGroup = new Definition();
+        $matcherServiceWithOutGroup->addTag('cmf_seo.suggestion_provider');
+        $this->setDefinition('matcher.without_group', $matcherServiceWithOutGroup);
+
+        $matcherPresentationService = new Definition();
+        $this->setDefinition('cmf_seo.error.suggestion_provider.controller', $matcherPresentationService);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'cmf_seo.error.suggestion_provider.controller',
+            'addSuggestionProvider',
+            array(new Reference('matcher.without_group'), 'default')
+        );
+    }
+}

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -60,14 +60,14 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled'  => false,
                 'provider_id' => null,
             ),
-        );
+            );
 
         $sources = array_map(function ($path) {
-                return __DIR__.'/../../Resources/Fixtures/'.$path;
+            return __DIR__.'/../../Resources/Fixtures/'.$path;
         }, array(
-                'config/config.yml',
-                'config/config.php',
-                'config/config.xml',
+            'config/config.yml',
+            'config/config.php',
+            'config/config.xml',
         ));
 
         $this->assertProcessedConfigurationEquals($expectedConfiguration, $sources);

--- a/Tests/WebTest/SeoFrontendTest.php
+++ b/Tests/WebTest/SeoFrontendTest.php
@@ -57,9 +57,9 @@ class SeoFrontendTest extends BaseTestCase
 
         //test the meta tag entries
         $metaCrawler = $crawler->filter('head > meta')->reduce(function (Crawler $node) {
-                $nameValue = $node->attr('name');
+            $nameValue = $node->attr('name');
 
-                return 'title' === $nameValue || 'description' === $nameValue ||'keywords' === $nameValue;
+            return 'title' === $nameValue || 'description' === $nameValue ||'keywords' === $nameValue;
         });
 
         $actualMeta = $metaCrawler->extract('content', 'content');
@@ -162,5 +162,17 @@ class SeoFrontendTest extends BaseTestCase
         $linkCrawler = $crawler->filter('head > link');
         $expectedArray = array(array('alternate', 'http://localhost/en/alternate-locale-content', 'en'));
         $this->assertEquals($expectedArray, $linkCrawler->extract(array('rel', 'href', 'hreflang')));
+    }
+
+    public function testErrorHandling()
+    {
+        $crawler = $this->client->request('GET', '/content/content-1/content-depp');
+        $res = $this->client->getResponse();
+
+        $this->assertEquals(404, $res->getStatusCode());
+
+        $this->assertCount(1, $crawler->filter('html:contains("Exception-Test")'));
+        $this->assertCount(1, $crawler->filter('html:contains("parent - content-1")'));
+        $this->assertCount(1, $crawler->filter('html:contains("sibling - content-deeper")'));
     }
 }


### PR DESCRIPTION
As a follow up from #177 

Would like to spice up the frontend test only by adding one more level in the routes/contents created in the FixtureLoader to see both ancestor and parent suggestions.
