### PR TITLE
move hhvm to allowed failures until xml handling is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ env:
 
 matrix:
   allow_failures:
-    - env: SYMFONY_VERSION=dev-master
+    - php: hhvm
   include:
     - php: 5.5
       env: SYMFONY_VERSION=2.3.*
     - php: 5.5
       env: SYMFONY_VERSION=2.4.*
     - php: 5.5
-      env: SYMFONY_VERSION=dev-master
+      env: SYMFONY_VERSION=2.6.*
 
 before_script:
   - composer self-update


### PR DESCRIPTION
and while we are at it, make symfony 2.\* required.
