### PR TITLE
Sitemap generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* **2015-14-02**: implement sitemap generation
+* **2015-14-02**: [BC BREAK] Changed method visibility from private to public of SeoPresentation#getSeoMetadata()
 * **2014-10-04**: Custom exception controller for error handling
 
 1.1.0-RC3

--- a/CmfSeoBundle.php
+++ b/CmfSeoBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\SeoBundle;
 use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\DoctrinePhpcrMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 
+use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler\RegisterUrlInformationProviderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -26,6 +27,7 @@ class CmfSeoBundle extends Bundle
     {
         $container->addCompilerPass(new RegisterExtractorsPass());
         $container->addCompilerPass(new RegisterSuggestionProviderPass());
+        $container->addCompilerPass(new RegisterUrlInformationProviderPass());
 
         $this->buildPhpcrCompilerPass($container);
         $this->buildOrmCompilerPass($container);

--- a/Controller/SitemapController.php
+++ b/Controller/SitemapController.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Controller;
+
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * Controller to handle requests for sitemap.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SitemapController
+{
+    /**
+     * @var UrlInformationProviderInterface
+     */
+    private $urlProvider;
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var array
+     */
+    private $templates;
+
+    /**
+     * You should provide templates for html and xml.
+     *
+     * Json is serialized by default, but can be customized with a template
+     *
+     * @param UrlInformationProviderInterface $provider
+     * @param EngineInterface                 $templating
+     * @param array                           $templates  Hash map with key being the format,
+     *                                                    value the name of the twig template
+     *                                                    to render the sitemap in that format
+     */
+    public function __construct(
+        UrlInformationProviderInterface $provider,
+        EngineInterface $templating,
+        array $templates
+    ) {
+        $this->urlProvider = $provider;
+        $this->templating = $templating;
+        $this->templates = $templates;
+    }
+
+    /**
+     * @param string $_format The format of the sitemap.
+     *
+     * @return Response
+     */
+    public function indexAction($_format)
+    {
+        $supportedFormats = array_merge(array('json'), array_keys($this->templates));
+        if (!in_array($_format, $supportedFormats)) {
+            $text = sprintf(
+                'Unknown format %s, use one of %s.',
+                $_format,
+                implode(', ', $supportedFormats)
+            );
+
+            return new Response($text, 406);
+        }
+
+        $urls = $this->urlProvider->getUrlInformation();
+        if (isset($this->templates[$_format])) {
+            return new Response($this->templating->render($this->templates[$_format], array('urls' => $urls)));
+        }
+
+        return $this->createJsonResponse($urls);
+    }
+
+    /**
+     * @param array|UrlInformation[] $urls
+     *
+     * @return JsonResponse
+     */
+    private function createJsonResponse($urls)
+    {
+        $result = array();
+
+        foreach ($urls as $url) {
+            $result[] = $url->toArray();
+        }
+
+        return new JsonResponse($result);
+    }
+}

--- a/DependencyInjection/Compiler/RegisterUrlInformationProviderPass.php
+++ b/DependencyInjection/Compiler/RegisterUrlInformationProviderPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler adds custom url information provider to the phpcr chain provider.
+ *
+ * To do so you need to tag them with "cmf_seo.sitemap.url_information_provider".
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class RegisterUrlInformationProviderPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @throws LogicException If a tagged service is not public.
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // feature not activated means nothing to add
+        if (!$container->hasDefinition('cmf_seo.sitemap.url_information_provider')) {
+            return;
+        }
+
+        $chainProviderDefinition = $container->getDefinition('cmf_seo.sitemap.url_information_provider');
+        $taggedServices = $container->findTaggedServiceIds('cmf_seo.sitemap.url_information_provider');
+
+        foreach ($taggedServices as $id => $attributes) {
+            $priority = null;
+            foreach ($attributes as $attribute) {
+                if (isset($attribute['priority'])) {
+                    $priority = $attribute['priority'];
+                    break;
+                }
+            }
+            $priority = $priority ?: 0;
+
+            $chainProviderDefinition->addMethodCall('addProvider', array(new Reference($id), $priority));
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,7 +60,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->beforeNormalization()
                         ->ifTrue( function ($v) { return is_scalar($v); })
-                        ->then( function ($v) {
+                        ->then(function ($v) {
                             return array('enabled' => $v);
                         })
                     ->end()
@@ -83,6 +83,13 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('enable_parent_provider')->defaultValue(false)->end()
                         ->scalarNode('enable_sibling_provider')->defaultValue(false)->end()
+                    ->end()
+                ->end()
+                ->arrayNode('sitemap')
+                    ->addDefaultsIfNotSet()
+                    ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('default_chan_frequency')->defaultValue('always')->end()
                     ->end()
                 ->end()
             ->end()

--- a/Doctrine/Phpcr/SitemapUrlInformationProvider.php
+++ b/Doctrine/Phpcr/SitemapUrlInformationProvider.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr;
+
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Query\QueryException;
+use Jackalope\Transport\Logging\LoggerInterface;
+use PHPCR\Query\QueryInterface;
+use Psr\Log\LoggerInterface as PsrLogger;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
+use Symfony\Cmf\Bundle\SeoBundle\AlternateLocaleProviderInterface;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface;
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+use Symfony\Cmf\Bundle\SeoBundle\SeoPresentation;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+/**
+ * Provides UrlInformation for pages in a Doctrine PHPCR ODM back-end.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SitemapUrlInformationProvider implements UrlInformationProviderInterface
+{
+    /**
+     * @var AlternateLocaleProviderInterface
+     */
+    protected $alternateLocaleProvider;
+
+    /**
+     * @var ExtractorInterface
+     */
+    protected $titleExtractor;
+
+    /**
+     * @var DocumentManager
+     */
+    private $manager;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var SecurityContextInterface
+     */
+    private $publishWorkflowChecker;
+    /**
+     * @var string
+     */
+    private $defaultChanFrequency;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var SeoPresentation
+     */
+    private $seoPresentation;
+
+    /**
+     * @param DocumentManager $manager
+     * @param RouterInterface $router
+     * @param string $defaultChanFrequency
+     * @param PsrLogger $logger
+     * @param SeoPresentation $seoPresentation
+     * @param SecurityContextInterface $publishWorkflowChecker
+     */
+    public function __construct(
+        DocumentManager $manager,
+        RouterInterface $router,
+        $defaultChanFrequency,
+        PsrLogger $logger,
+        SeoPresentation $seoPresentation,
+        SecurityContextInterface $publishWorkflowChecker = null
+    ) {
+        $this->manager = $manager;
+        $this->router = $router;
+        $this->defaultChanFrequency = $defaultChanFrequency;
+        $this->logger = $logger;
+        $this->seoPresentation = $seoPresentation;
+        $this->publishWorkflowChecker = $publishWorkflowChecker;
+    }
+
+    /**
+     * {@inheritDocs}
+     */
+    public function getUrlInformation()
+    {
+        $contentDocuments = $this->fetchSitemapDocuments();
+        $urlInformationList = array();
+
+        foreach ($contentDocuments as $document) {
+            if (null != $this->publishWorkflowChecker &&
+                !$this->publishWorkflowChecker->isGranted(array(PublishWorkflowChecker::VIEW_ATTRIBUTE), $document)
+            ) {
+                continue;
+            }
+
+            try {
+                $urlInformationList[] = $this->computeUrlInformationFromSitemapDocument($document);
+            } catch (\Exception $e) {
+                $this->logger->info($e->getMessage());
+            }
+        }
+
+        return $urlInformationList;
+    }
+
+    /**
+     * @param AlternateLocaleProviderInterface $alternateLocaleProvider
+     */
+    public function setAlternateLocaleProvider(AlternateLocaleProviderInterface $alternateLocaleProvider)
+    {
+        $this->alternateLocaleProvider = $alternateLocaleProvider;
+    }
+
+    /**
+     * Wrapper to fetch the sitemap documents from database.
+     *
+     * @return object[]
+     *
+     * @throws QueryException
+     */
+    protected function fetchSitemapDocuments()
+    {
+        // todo rewrite query when https://github.com/symfony-cmf/CoreBundle/issues/126 is ready
+        return $this->manager->createQuery(
+            "SELECT * FROM [nt:unstructured] WHERE (visible_for_sitemap = true)",
+            QueryInterface::JCR_SQL2
+        )->execute();
+    }
+
+    /**
+     * Transforms a single sitemap document into url information.
+     *
+     * A sitemap document is a document, which should be exposed on a sitemap.
+     *
+     * @param object $document
+     *
+     * @return UrlInformation
+     */
+    protected function computeUrlInformationFromSitemapDocument($document)
+    {
+        $urlInformation = new UrlInformation();
+        $urlInformation->setLocation($this->router->generate($document, array(), true));
+        $urlInformation->setChangeFrequency($this->defaultChanFrequency);
+
+        if ($this->alternateLocaleProvider) {
+            $collection = $this->alternateLocaleProvider->createForContent($document);
+            $urlInformation->setAlternateLocales($collection->toArray());
+        }
+
+        $seoMetadata = $this->seoPresentation->getSeoMetadata($document);
+        if (null !== $seoMetadata->getTitle()) {
+            $urlInformation->setLabel($seoMetadata->getTitle());
+            return $urlInformation;
+        }
+        return $urlInformation;
+    }
+}

--- a/Model/UrlInformation.php
+++ b/Model/UrlInformation.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Model;
+use Symfony\Cmf\Bundle\SeoBundle\Exception\InvalidArgumentException;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class UrlInformation
+{
+    /**
+     * Decides whether the content is visible on sitemap.
+     *
+     * @var bool
+     */
+    private $visible;
+
+    /**
+     * @var string
+     */
+    private $location;
+
+    /**
+     * @var \DateTime
+     */
+    private $lastModification;
+
+    /**
+     * @var string One of the official/allowed.
+     */
+    private $changeFrequency;
+
+    /**
+     * @var float
+     */
+    private $priority;
+
+    /**
+     * @var array
+     */
+    private $allowedChangeFrequencies = array('always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never');
+
+    /**
+     * @var string $label As a string to display the route i.e. in html views.
+     */
+    private $label;
+
+    /**
+     * @var AlternateLocale[]
+     */
+    private $alternateLocales;
+
+    public function __construct()
+    {
+        $this->alternateLocales = array();
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isVisible()
+    {
+        return $this->visible;
+    }
+
+    /**
+     * @param boolean $visible
+     */
+    public function setVisible($visible)
+    {
+        $this->visible = $visible;
+    }
+
+    public function toArray()
+    {
+        $result = array(
+            'loc'               => $this->location,
+            'label'             => $this->label,
+            'changefreq'        => $this->changeFrequency,
+            'lastmod'           => $this->lastModification,
+            'priority'          => $this->priority,
+            'alternate_locales' => array()
+        );
+
+        foreach ($this->alternateLocales as $locale) {
+            $result['alternate_locales'][] = array('href' => $locale->href, 'href_locale' => $locale->hrefLocale);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string
+     */
+    public function getChangeFrequency()
+    {
+        return $this->changeFrequency;
+    }
+
+    /**
+     * @param string $changeFrequency One of the official/allowed ones.
+     *
+     * @return $this
+     */
+    public function setChangeFrequency($changeFrequency)
+    {
+        if (!in_array($changeFrequency, $this->allowedChangeFrequencies)) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid change frequency use one of %s.', implode(', ', $this->allowedChangeFrequencies))
+            );
+        }
+
+        $this->changeFrequency = $changeFrequency;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastModification()
+    {
+        return $this->lastModification;
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     *
+     * @return $this
+     */
+    public function setLastModification(\DateTime $dateTime)
+    {
+        $lastmod = $dateTime->format('c');
+        $this->lastModification = $lastmod;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param string $location
+     *
+     * @return $this
+     */
+    public function setLocation($location)
+    {
+        $this->location = $location;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @param float $priority
+     *
+     * @return $this
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setLabel($label)
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * @return array|AlternateLocale[]
+     */
+    public function getAlternateLocales()
+    {
+        return $this->alternateLocales;
+    }
+
+    /**
+     * @param array|AlternateLocale[] $alternateLocales
+     */
+    public function setAlternateLocales($alternateLocales)
+    {
+        $this->alternateLocales = $alternateLocales;
+    }
+
+    /**
+     * @param AlternateLocale $alternateLocale
+     */
+    public function addAlternateLocale(AlternateLocale $alternateLocale)
+    {
+        $this->alternateLocales[] = $alternateLocale;
+    }
+}

--- a/Resources/config/phpcr-sitemap.xml
+++ b/Resources/config/phpcr-sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container
+        xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_seo.sitemap.phpcr_provider.class">Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SitemapUrlInformationProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="cmf_seo.sitemap.phpcr_provider" class="%cmf_seo.sitemap.phpcr_provider.class%" public="false">
+            <argument type="service" id="doctrine_phpcr.odm.default_document_manager"/>
+            <argument type="service" id="router" />
+            <argument>%cmf_seo.sitemap.default_change_frequency%</argument>
+            <argument type="service" id="logger" />
+            <argument type="service" id="cmf_seo.presentation" />
+            <argument type="service" id="cmf_core.publish_workflow.checker" />
+
+            <tag name="cmf_seo.sitemap.url_information_provider" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/routing/sitemap.xml
+++ b/Resources/config/routing/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="cmf_seo_sitemap" pattern="/sitemap.{_format}">
+        <default key="_controller">cmf_seo.sitemap.controller:indexAction</default>
+        <default key="_format">html</default>
+    </route>
+
+</routes>

--- a/Resources/config/sitemap.xml
+++ b/Resources/config/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container
+        xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_seo.sitemap.controller.class">Symfony\Cmf\Bundle\SeoBundle\Controller\SitemapController</parameter>
+        <parameter key="cmf_seo.sitemap.url_information_provider.class">Symfony\Cmf\Bundle\SeoBundle\Sitemap\ChainProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="cmf_seo.sitemap.controller" class="%cmf_seo.sitemap.controller.class%">
+            <argument type="service" id="cmf_seo.sitemap.url_information_provider" />
+            <argument type="service" id="templating" />
+            <argument type="collection">
+                <argument key="xml">CmfSeoBundle:Sitemap:index.xml.twig</argument>
+                <argument key="html">CmfSeoBundle:Sitemap:index.html.twig</argument>
+            </argument>
+        </service>
+        <service id="cmf_seo.sitemap.url_information_provider" class="%cmf_seo.sitemap.url_information_provider.class%" />
+    </services>
+</container>

--- a/Resources/views/Sitemap/index.html.twig
+++ b/Resources/views/Sitemap/index.html.twig
@@ -1,0 +1,7 @@
+<ul class="cmf-sitemap">
+    {% for url in urls %}
+        <li>
+            <a href="{{ url.location }}" title="{{ url.label }}">{{ url.label }}</a>
+        </li>
+    {% endfor %}
+</ul>

--- a/Resources/views/Sitemap/index.xml.twig
+++ b/Resources/views/Sitemap/index.xml.twig
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    {% for url in urls %}
+        <url>
+            <loc>{{ url.location }}</loc>
+            <lastmod>{{ url.lastModification }}</lastmod>
+            <changefreq>{{ url.changeFrequency }}</changefreq>
+            {% if url.alternateLocales is defined and url.alternateLocales|length > 0 %}
+                {% for locale in url.alternateLocales %}
+                    <xhtml:link rel="alternate" hreflang="{{ locale.hrefLocale }}" href="{{ locale.href }}"/>
+                {% endfor %}
+            {% endif %}
+        </url>
+    {% endfor %}
+</urlset>

--- a/SeoPresentation.php
+++ b/SeoPresentation.php
@@ -136,14 +136,9 @@ class SeoPresentation implements SeoPresentationInterface
     }
 
     /**
-     * Gets the SeoMetadata based on the content that contains the content.
-     *
-     * @param object $content
-     *
-     * @throws Exception\InvalidArgumentException
-     * @return SeoMetadata
+     * {@inheritDoc}
      */
-    private function getSeoMetadata($content)
+    public function getSeoMetadata($content)
     {
         if ($content instanceof SeoAwareInterface) {
             $contentSeoMetadata = $content->getSeoMetadata();

--- a/Sitemap/ChainProvider.php
+++ b/Sitemap/ChainProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Sitemap;
+
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+
+/**
+ * Accepts providers and merges the result of all providers into
+ * a combined list of UrlInformation
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class ChainProvider implements UrlInformationProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $providers = array();
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addProvider(UrlInformationProviderInterface $provider, $priority = 0)
+    {
+        if (empty($this->providers[$priority])) {
+            $this->providers[$priority] = array();
+        }
+        $this->providers[$priority][] = $provider;
+    }
+
+    /**
+     * @return UrlInformationProviderInterface[]
+     */
+    private function getSortedProviders()
+    {
+        $sortedProviders = array();
+        ksort($this->providers);
+
+        foreach ($this->providers as $providers) {
+            $sortedProviders = array_merge($sortedProviders, $providers);
+        };
+
+        return $sortedProviders;
+    }
+
+    /**
+     * @return UrlInformation[]
+     */
+    public function getUrlInformation()
+    {
+        $urlInformation = array();
+
+        foreach ($this->getSortedProviders() as $provider) {
+            $urlInformation = array_merge($urlInformation, $provider->getUrlInformation());
+        }
+
+        return $urlInformation;
+    }
+}

--- a/Sitemap/UrlInformationProviderInterface.php
+++ b/Sitemap/UrlInformationProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Sitemap;
+
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+
+/**
+ * Providers are able to create a list of UrlInformation for the sitemap creation.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+interface UrlInformationProviderInterface
+{
+    /**
+     * @return UrlInformation[]
+     */
+    public function getUrlInformation();
+}

--- a/SitemapElementInterface.php
+++ b/SitemapElementInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle;
+
+/**
+ * Models implementing this interface can indicate whether they should be listed in the sitemap or not.
+ *
+ * For PHPCR-ODM documents used with the \Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SitemapUrlInformationProvider,
+ * make sure to call the property that stores this information "visible_for_sitemap",
+ * as the provider uses the property in the query rather than loading all documents and checking the method.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+interface SitemapElementInterface
+{
+    /**
+     * Decision whether a document should be visible
+     * in sitemap or not.
+     *
+     * @return bool
+     */
+    public function isVisibleInSitemap();
+}

--- a/Tests/Functional/Doctrine/Phpcr/SitemapUrlInformationProviderTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/SitemapUrlInformationProviderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Functional\Doctrine\Phpcr;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SitemapUrlInformationProvider;
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocale;
+use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SitemapUrlInformationProviderTest extends BaseTestCase
+{
+    /**
+     * @var DocumentManager
+     */
+    protected $dm;
+    protected $base;
+
+    /**
+     * @var SitemapUrlInformationProvider
+     */
+    protected $provider;
+    protected $alternateLocaleProvider;
+    protected $logger;
+    protected $presentation;
+
+    public function setUp()
+    {
+        $this->db('PHPCR')->createTestNode();
+        $this->dm = $this->db('PHPCR')->getOm();
+        $this->base = $this->dm->find(null, '/test');
+
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\DataFixtures\Phpcr\LoadSitemapData',
+        ));
+
+        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->presentation = $this
+            ->getMockBuilder('\Symfony\Cmf\Bundle\SeoBundle\SeoPresentation')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->provider = new SitemapUrlInformationProvider(
+            $this->dm,
+            $this->getContainer()->get('router'),
+            'always',
+            $this->logger,
+            $this->presentation,
+            $this->getContainer()->get('cmf_core.publish_workflow.checker')
+        );
+        $this->alternateLocaleProvider = $this
+            ->getMock('\Symfony\Cmf\Bundle\SeoBundle\AlternateLocaleProviderInterface');
+        $this->provider->setAlternateLocaleProvider($this->alternateLocaleProvider);
+
+        $alternateLocale = new AlternateLocale('test', 'de');
+        $this->alternateLocaleProvider
+            ->expects($this->any())
+            ->method('createForContent')
+            ->will($this->returnValue(new ArrayCollection(array($alternateLocale))));
+    }
+
+    public function testRouteGeneration()
+    {
+        // expected methods/class
+        $seoMetadata = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadataInterface');
+        $this->presentation
+            ->expects($this->any())
+            ->method('getSeoMetadata')
+            ->will($this->returnValue($seoMetadata));
+        $seoMetadata->expects($this->any())->method('getTitle')->will($this->returnValue('test-title'));
+
+        $routeInformation = $this->provider->getUrlInformation();
+
+        $this->assertCount(2, $routeInformation);
+        $actualValues = array();
+        foreach ($routeInformation as $information) {
+            $actualValues[] = $information->toArray();
+        }
+        $expectedValues = array(
+            array(
+                'loc' => 'http://localhost/sitemap-aware',
+                'label' => 'test-title',
+                'changefreq' => 'always',
+                'lastmod'  => '',
+                'priority' => '',
+                'alternate_locales' => array(
+                    array('href' => 'test', 'href_locale' => 'de'),
+                ),
+            ),
+            array(
+                'loc' => 'http://localhost/sitemap-aware-publish',
+                'label' => 'test-title',
+                'changefreq' => 'always',
+                'lastmod'  => '',
+                'priority' => '',
+                'alternate_locales' => array(
+                    array('href' => 'test', 'href_locale' => 'de'),
+                ),
+            ),
+        );
+        $this->assertEquals($expectedValues, $actualValues);
+    }
+}

--- a/Tests/Resources/DataFixtures/Phpcr/LoadSitemapData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadSitemapData.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\DataFixtures\Phpcr;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use PHPCR\Util\NodeHelper;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
+use Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SeoMetadata;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\AlternateLocaleContent;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SeoAwareContent;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\ContentWithExtractors;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SitemapAwareContent;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SitemapAwareWithPublishWorkflowContent;
+
+class LoadSitemapData implements FixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test');
+
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test/content');
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test/routes');
+
+        $contentRoot = $manager->find(null, '/test/content');
+        $routeRoot = $manager->find(null, '/test/routes');
+
+        $sitemapAwareContent = new SitemapAwareContent();
+        $sitemapAwareContent
+            ->setIsVisibleForSitemap(true)
+            ->setTitle('Sitemap Aware Content')
+            ->setName('sitemap-aware')
+            ->setParentDocument($contentRoot)
+            ->setBody('Content for that is sitemap aware');
+        $manager->persist($sitemapAwareContent);
+        $manager->bindTranslation($sitemapAwareContent, 'en');
+        $sitemapAwareContent
+            ->setTitle('Content für die Sitemap')
+            ->setBody('Das sollte die Deutsche Version des Contents sein.');
+        $manager->bindTranslation($sitemapAwareContent, 'de');
+
+        $route = new Route();
+        $route->setPosition($routeRoot, 'sitemap-aware');
+        $route->setContent($sitemapAwareContent);
+        $manager->persist($route);
+
+        $nonPublishedContent = new SitemapAwareWithPublishWorkflowContent();
+        $nonPublishedContent->setIsVisibleForSitemap(true);
+        $nonPublishedContent->setPublishable(false);
+        $nonPublishedContent
+            ->setTitle('Sitemap Aware Content non publish')
+            ->setName('sitemap-aware-non-publish')
+            ->setParentDocument($contentRoot)
+            ->setBody('Content for that is sitemap aware, that is not publish');
+        $manager->persist($nonPublishedContent);
+
+        $route = new Route();
+        $route->setPosition($routeRoot, 'sitemap-aware-non-publish');
+        $route->setContent($nonPublishedContent);
+        $manager->persist($route);
+
+        $publishedContent = new SitemapAwareWithPublishWorkflowContent();
+        $publishedContent->setIsVisibleForSitemap(true);
+        $publishedContent->setPublishable(true);
+        $publishedContent
+            ->setTitle('Sitemap Aware Content publish')
+            ->setName('sitemap-aware-publish')
+            ->setParentDocument($contentRoot)
+            ->setBody('Content for that is sitemap aware, that is publish');
+        $manager->persist($publishedContent);
+
+        $route = new Route();
+        $route->setPosition($routeRoot, 'sitemap-aware-publish');
+        $route->setContent($publishedContent);
+        $manager->persist($route);
+
+        $manager->flush();
+    }
+}

--- a/Tests/Resources/Document/SitemapAwareContent.php
+++ b/Tests/Resources/Document/SitemapAwareContent.php
@@ -1,28 +1,23 @@
 <?php
 
-/*
- * This file is part of the Symfony CMF package.
- *
- * (c) 2011-2014 Symfony CMF
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
-use Symfony\Cmf\Component\Routing\RouteReferrersInterface;
-use Symfony\Component\Routing\Route;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SitemapElementInterface;
+use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
+use Symfony\Component\Routing\Route;
 
 /**
- * @PHPCRODM\Document(translator="attribute")
+ * @PHPCRODM\Document(referenceable=true, translator="attribute")
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
  */
-class AlternateLocaleContent extends ContentBase implements
-    RouteReferrersInterface,
-    TranslatableInterface
+class SitemapAwareContent extends ContentBase implements
+    RouteReferrersReadInterface,
+    TranslatableInterface,
+    SitemapElementInterface
 {
     /**
      * @var string
@@ -30,13 +25,6 @@ class AlternateLocaleContent extends ContentBase implements
      * @PHPCRODM\Locale
      */
     protected $locale;
-
-    /**
-     * @var string
-     *
-     * @PHPCRODM\String(translated=true)
-     */
-    protected $title;
 
     /**
      * @var ArrayCollection|Route[]
@@ -48,9 +36,43 @@ class AlternateLocaleContent extends ContentBase implements
      */
     protected $routes;
 
+    /**
+     * @var bool
+     *
+     * @PHPCRODM\Boolean(property="visible_for_sitemap")
+     */
+    private $isVisibleForSitemap;
+
+    /**
+     * @var string
+     *
+     * @PHPCRODM\String(translated=true)
+     */
+    protected $title;
+
     public function __construct()
     {
         $this->routes = new ArrayCollection();
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isVisibleInSitemap()
+    {
+        return $this->isVisibleForSitemap;
+    }
+
+    /**
+     * @param boolean $isVisibleForSitemap
+     *
+     * @return SitemapAwareContent
+     */
+    public function setIsVisibleForSitemap($isVisibleForSitemap)
+    {
+        $this->isVisibleForSitemap = $isVisibleForSitemap;
+
+        return $this;
     }
 
     /**
@@ -82,6 +104,7 @@ class AlternateLocaleContent extends ContentBase implements
     {
         return $this->routes;
     }
+
 
     /**
      * @return string|boolean The locale of this model or false if

--- a/Tests/Resources/Document/SitemapAwareWithPublishWorkflowContent.php
+++ b/Tests/Resources/Document/SitemapAwareWithPublishWorkflowContent.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodInterface;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Symfony\Cmf\Bundle\SeoBundle\SitemapElementInterface;
+use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
+
+/**
+ * @PHPCRODM\Document(referenceable=true)
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SitemapAwareWithPublishWorkflowContent extends ContentBase implements
+    PublishableInterface,
+    PublishTimePeriodInterface,
+    RouteReferrersReadInterface,
+    SitemapElementInterface
+{
+    /**
+     * @var ArrayCollection|Route[]
+     *
+     * @PHPCRODM\Referrers(
+     *  referringDocument="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route",
+     *  referencedBy="content"
+     * )
+     */
+    protected $routes;
+
+    /**
+     * @var bool
+     *
+     * @PHPCRODM\Boolean(property="visible_for_sitemap")
+     */
+    private $isVisibleForSitemap;
+
+    /**
+     * @var boolean whether this content is publishable
+     *
+     * @PHPCRODM\Boolean
+     */
+    protected $publishable = true;
+
+    /**
+     * @var \DateTime|null publication start time
+     */
+    protected $publishStartDate;
+
+    /**
+     * @var \DateTime|null publication end time
+     */
+    protected $publishEndDate;
+
+    public function __construct()
+    {
+        $this->routes = new ArrayCollection();
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isVisibleInSitemap()
+    {
+        return $this->isVisibleForSitemap;
+    }
+
+    /**
+     * @param boolean $isVisibleForSitemap
+     *
+     * @return SitemapAwareContent
+     */
+    public function setIsVisibleForSitemap($isVisibleForSitemap)
+    {
+        $this->isVisibleForSitemap = $isVisibleForSitemap;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setPublishable($publishable)
+    {
+        return $this->publishable = (bool) $publishable;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPublishable()
+    {
+        return $this->publishable;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPublishStartDate()
+    {
+        return $this->publishStartDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setPublishStartDate(\DateTime $publishStartDate = null)
+    {
+        $this->publishStartDate = $publishStartDate;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPublishEndDate()
+    {
+        return $this->publishEndDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setPublishEndDate(\DateTime $publishEndDate = null)
+    {
+        $this->publishEndDate = $publishEndDate;
+
+        return $this;
+    }
+
+    /**
+     * Get the routes that point to this content.
+     *
+     * @return \Symfony\Component\Routing\Route[] Route instances that point to this content
+     */
+    public function getRoutes()
+    {
+        return $this->routes;
+    }
+}

--- a/Tests/Resources/Fixtures/sitemap/sitemap.xml
+++ b/Tests/Resources/Fixtures/sitemap/sitemap.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    <url>
+        <loc>http://www.test-alternate-locale.de</loc>
+        <lastmod>2014-11-07T00:00:00+01:00</lastmod>
+        <changefreq>never</changefreq>
+        <xhtml:link rel="alternate" hreflang="en" href="http://www.test-alternate-locale.com"/>
+    </url>
+    <url>
+        <loc>http://www.test-domain.de</loc>
+        <lastmod>2014-11-06T00:00:00+01:00</lastmod>
+        <changefreq>always</changefreq>
+    </url>
+</urlset>

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -23,6 +23,7 @@ class AppKernel extends TestKernel
             new \Symfony\Cmf\Bundle\SeoBundle\CmfSeoBundle(),
             new \Burgov\Bundle\KeyValueFormBundle\BurgovKeyValueFormBundle(),
             new \Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle(),
+            new Symfony\Cmf\Bundle\CoreBundle\CmfCoreBundle(),
         ));
     }
 

--- a/Tests/Resources/app/config/cmf_seo.phpcr.yml
+++ b/Tests/Resources/app/config/cmf_seo.phpcr.yml
@@ -37,3 +37,8 @@ sonata_admin:
                 label: Content
                 items:
                     - sonata.admin.seo_content
+
+cmf_core:
+    persistence:
+        phpcr:
+            basepath: /test

--- a/Tests/Resources/app/config/cmf_seo.yml
+++ b/Tests/Resources/app/config/cmf_seo.yml
@@ -14,6 +14,7 @@ cmf_seo:
     error:
         enable_parent_provider: true
         enable_sibling_provider: true
+    sitemap: true
 
 cmf_routing:
     chain:
@@ -23,3 +24,7 @@ cmf_routing:
 
 twig:
     exception_controller: cmf_seo.error.suggestion_provider.controller:showAction
+
+cmf_core:
+    multilang:
+        locales: [en, de]

--- a/Tests/Resources/app/config/routing.php
+++ b/Tests/Resources/app/config/routing.php
@@ -6,6 +6,9 @@ $collection = new RouteCollection();
 $collection->addCollection(
     $loader->import(CMF_TEST_CONFIG_DIR.'/routing/sonata_routing.yml')
 );
+$collection->addCollection(
+    $loader->import(__DIR__.'/../../../../Resources/config/routing/sitemap.xml')
+);
 // $collection->addCollection(
 //     $loader->import(__DIR__.'/routing/my_test_routing.yml')
 // );

--- a/Tests/Unit/Controller/SitemapControllerTest.php
+++ b/Tests/Unit/Controller/SitemapControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Controller;
+
+use Symfony\Cmf\Bundle\SeoBundle\Controller\SitemapController;
+use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocale;
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\ChainProvider;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SitemapControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @var UrlInformationProviderInterface
+     */
+    private $provider;
+
+    /**
+     * @var SitemapController
+     */
+    private $controller;
+
+    public function setUp()
+    {
+        $this->provider = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface');
+        $this->createRoutes();
+
+        $this->templating = $this->getMock('Symfony\Component\Templating\EngineInterface');
+        $this->controller = new SitemapController(
+            $this->provider,
+            $this->templating,
+            array(
+                'xml'  => 'CmfSeoBundle:Sitemap:index.xml.twig',
+                'html' => 'CmfSeoBundle:Sitemap:index.html.twig',
+            )
+        );
+    }
+
+    public function testRequestJson()
+    {
+        /** @var Response $response */
+        $response = $this->controller->indexAction('json');
+        $expected = array(
+            array(
+                'loc'               => 'http://www.test-alternate-locale.de',
+                'label'             => 'Test alternate locale',
+                'changefreq'        => 'never',
+                'lastmod'           => '2014-11-07T00:00:00+01:00',
+                'priority'          => 0.85,
+                'alternate_locales' => array(
+                    array('href' => 'http://www.test-alternate-locale.com', 'href_locale' => 'en')
+                ),
+            ),
+            array(
+                'loc'               => 'http://www.test-domain.de',
+                'label'             => 'Test label',
+                'changefreq'        => 'always',
+                'lastmod'           => '2014-11-06T00:00:00+01:00',
+                'priority'          => 0.85,
+                'alternate_locales' => array(),
+            ),
+        );
+
+        $this->assertEquals($expected, json_decode($response->getContent(), true));
+    }
+
+    public function testRequestXml()
+    {
+        $response = new Response('some-xml-string');
+        $this->templating->expects($this->once())->method('render')->will($this->returnValue($response));
+
+        /** @var Response $response */
+        $response = $this->controller->indexAction('xml');
+
+        $this->assertEquals(new Response('some-xml-string'), $response->getContent());
+    }
+
+    public function testRequestHtml()
+    {
+        $expectedResponse = new Response('some-html-string');
+        $this->templating->expects($this->once())->method('render')->will($this->returnValue($expectedResponse));
+
+        /** @var Response $response */
+        $response = $this->controller->indexAction('html');
+
+        $this->assertEquals($expectedResponse, $response->getContent());
+    }
+
+    private function createRoutes()
+    {
+        $urls = array();
+
+        $simpleUrl = new UrlInformation();
+        $simpleUrl
+            ->setLocation('http://www.test-domain.de')
+            ->setChangeFrequency('always')
+            ->setLabel('Test label')
+            ->setPriority(0.85)
+            ->setLastModification(new \DateTime('2014-11-06', new \DateTimeZone('Europe/Berlin')))
+        ;
+
+        $urlWithAlternateLocale = new UrlInformation();
+        $urlWithAlternateLocale
+            ->setLocation('http://www.test-alternate-locale.de')
+            ->setChangeFrequency('never')
+            ->setLabel('Test alternate locale')
+            ->setPriority(0.85)
+            ->setLastModification(new \DateTime('2014-11-07', new \DateTimeZone('Europe/Berlin')))
+        ;
+        $alternateLocale = new AlternateLocale('http://www.test-alternate-locale.com', 'en');
+        $urlWithAlternateLocale->addAlternateLocale($alternateLocale);
+
+        $urls[] = $urlWithAlternateLocale;
+        $urls[] = $simpleUrl;
+
+        $this->provider->expects($this->any())->method('getUrlInformation')->will($this->returnValue($urls));
+    }
+
+    private function getFileContent($type)
+    {
+        $basePath = __DIR__.'/../../Resources/Fixtures/sitemap/sitemap';
+
+        return file_get_contents($basePath.'.'.$type);
+    }
+}

--- a/Tests/Unit/DependencyInjection/Compiler/RegisterUrlInformationProviderPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/RegisterUrlInformationProviderPassTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Symfony\Cmf\SeoBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\Compiler\RegisterUrlInformationProviderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class RegisterUrlInformationProviderPassTest extends AbstractCompilerPassTestCase
+{
+
+    /**
+     * Register the compiler pass under test, just like you would do inside a bundle's load()
+     * method:
+     *
+     *   $container->addCompilerPass(new MyCompilerPass());
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RegisterUrlInformationProviderPass());
+    }
+
+    public function testTags()
+    {
+        $nonProviderService = new Definition();
+        $this->setDefinition('some_service', $nonProviderService);
+
+        $providerService = new Definition();
+        $providerService->addTag('cmf_seo.sitemap.url_information_provider');
+        $this->setDefinition('provider_service', $providerService);
+
+        $providerServiceWithPriority = new Definition();
+        $providerServiceWithPriority->addTag(
+            'cmf_seo.sitemap.url_information_provider',
+            array('priority' => 1)
+        );
+        $this->setDefinition('provider_service_priority', $providerServiceWithPriority);
+
+        $chainProvider = new Definition();
+        $this->setDefinition('cmf_seo.sitemap.url_information_provider', $chainProvider);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'cmf_seo.sitemap.url_information_provider',
+            'addProvider',
+            array(new Reference('provider_service'), 0)
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'cmf_seo.sitemap.url_information_provider',
+            'addProvider',
+            array(new Reference('provider_service_priority'), 1)
+        );
+    }
+}

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -60,6 +60,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled'  => false,
                 'provider_id' => null,
             ),
+            'sitemap' => array(
+                'enabled' => false,
+                'default_chan_frequency' => 'always'
+            ),
             );
 
         $sources = array_map(function ($path) {

--- a/Tests/Unit/Model/UrlInformationTest.php
+++ b/Tests/Unit/Model/UrlInformationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Model;
+
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class UrlInformationTest extends \PHPUnit_Framework_Testcase
+{
+    /**
+     * @var UrlInformation
+     */
+    private $model;
+
+    public function setUp()
+    {
+        $this->model = new UrlInformation();
+    }
+
+    /**
+     * @expectedException Symfony\Cmf\Bundle\SeoBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid change frequency use one of always, hourly, daily, weekly, monthly, yearly, never.
+     */
+    public function testSetChangeFrequencyShouldThrowExceptionForInvalidArguments()
+    {
+        $this->model->setChangeFrequency('some one');
+    }
+
+    public function testValidChangeFrequency()
+    {
+        $this->model->setChangeFrequency('never');
+
+        $this->assertEquals('never', $this->model->getChangeFrequency());
+    }
+}

--- a/Tests/Unit/Sitemap/ChainProviderTest.php
+++ b/Tests/Unit/Sitemap/ChainProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
+
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\ChainProvider;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class ChainProviderTest extends \PHPUnit_Framework_Testcase
+{
+    /**
+     * @var ChainProvider
+     */
+    private $chainProvider;
+
+    public function setUp()
+    {
+        $this->chainProvider = new ChainProvider();
+    }
+
+    public function testInlineInput()
+    {
+        $providerOne = $this->getMock('\Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface');
+        $providerTwo = $this->getMock('\Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface');
+
+        $this->chainProvider->addProvider($providerOne);
+        $this->chainProvider->addProvider($providerTwo);
+
+        $providerOne->expects($this->once())->method('getUrlInformation')->will($this->returnValue(array('info-one')));
+        $providerTwo->expects($this->once())->method('getUrlInformation')->will($this->returnValue(array('info-two')));
+
+        $actualList = $this->chainProvider->getUrlInformation();
+        $expectedList = array('info-one', 'info-two');
+
+        $this->assertEquals($expectedList, $actualList);
+    }
+
+    public function testPrioritisedInput()
+    {
+
+        $providerBeforeAll = $this->getMock('\Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface');
+        $providerFirst = $this->getMock('\Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface');
+        $providerAfterAll = $this->getMock('\Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProviderInterface');
+
+        $this->chainProvider->addProvider($providerFirst, 1);
+        $this->chainProvider->addProvider($providerBeforeAll, 0);
+        $this->chainProvider->addProvider($providerAfterAll, 2);
+
+        $providerFirst
+            ->expects($this->once())
+            ->method('getUrlInformation')
+            ->will($this->returnValue(array('info-first')));
+        $providerBeforeAll
+            ->expects($this->once())
+            ->method('getUrlInformation')
+            ->will($this->returnValue(array('info-before-all')));
+        $providerAfterAll
+            ->expects($this->once())
+            ->method('getUrlInformation')
+            ->will($this->returnValue(array('info-after-all')));
+
+        $actualList = $this->chainProvider->getUrlInformation();
+        $expectedList = array('info-before-all', 'info-first', 'info-after-all');
+
+        $this->assertEquals($expectedList, $actualList);
+    }
+}

--- a/Tests/WebTest/SitemapTest.php
+++ b/Tests/WebTest/SitemapTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\WebTest;
+
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpKernel\Client;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class SitemapTest extends BaseTestCase
+{
+    /** @var  Client */
+    private $client;
+
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\DataFixtures\Phpcr\LoadSitemapData',
+        ));
+        $this->client = $this->createClient();
+    }
+
+    /**
+     * @param $format
+     *
+     * @dataProvider getFormats
+     */
+    public function testSitemap($format)
+    {
+        $this->client->request('GET', '/sitemap.'.$format);
+        $res = $this->client->getResponse();
+
+        $this->assertEquals(200, $res->getStatusCode());
+        $content = $res->getContent();
+        if ('html' === $format || 'xml' === $format) {
+            $this->assertXmlStringEqualsXmlString($this->getContent($format), $content);
+        } else {
+            $this->assertEquals($this->getContent($format), $content);
+        }
+    }
+
+    public function getFormats()
+    {
+        return array(
+            array('html'), array('xml'), array('json')
+        );
+    }
+
+    public function getContent($format)
+    {
+        $data = array(
+            'html' => '<ul class="cmf-sitemap">
+                          <li>
+                            <a href="http://localhost/sitemap-aware" title="Sitemap Aware Content">Sitemap Aware Content</a>
+                          </li>
+                          <li>
+                            <a href="http://localhost/sitemap-aware-publish" title="Sitemap Aware Content publish">Sitemap Aware Content publish</a>
+                          </li>
+                       </ul>',
+            'xml'  => '<?xml version="1.0"?>
+                        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+                          <url>
+                            <loc>http://localhost/sitemap-aware</loc>
+                            <lastmod/>
+                            <changefreq>always</changefreq>
+                            <xhtml:link href="http://localhost/sitemap-aware?_locale=de" hreflang="de" rel="alternate"/>
+                          </url>
+                          <url>
+                            <loc>http://localhost/sitemap-aware-publish</loc>
+                            <lastmod/>
+                            <changefreq>always</changefreq>
+                          </url>
+                        </urlset>',
+            'json' => '[{"loc":"http:\/\/localhost\/sitemap-aware","label":"Sitemap Aware Content","changefreq":"always","lastmod":null,"priority":null,"alternate_locales":[{"href":"http:\/\/localhost\/sitemap-aware?_locale=de","href_locale":"de"}]},{"loc":"http:\/\/localhost\/sitemap-aware-publish","label":"Sitemap Aware Content publish","changefreq":"always","lastmod":null,"priority":null,"alternate_locales":[]}]',
+        );
+
+        return $data[$format];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #132 
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/issues/607

Started working on that feature. That would be the task:

- [x] implement generator for phpcr content
- [x] create decider for content which should be published
- [x] create controller for the output
- [x] general configuration and optional activating of the phpcr generator