### PR TITLE
Allow disabling of content listener.

### DIFF
--- a/DependencyInjection/CmfSeoExtension.php
+++ b/DependencyInjection/CmfSeoExtension.php
@@ -79,8 +79,13 @@ class CmfSeoExtension extends Extension
             $this->loadSonataAdmin($config['sonata_admin_extension'], $loader, $container, $sonataBundles);
         }
 
-        if ($this->isConfigEnabled($container, $config['alternate_locale'])) {
-            $this->loadAlternateLocaleProvider($config['alternate_locale'], $container);
+        if ($config['enable_content_listener']) {
+
+            $loader->load('content-listener.xml');
+
+            if ($this->isConfigEnabled($container, $config['alternate_locale'])) {
+                $this->loadAlternateLocaleProvider($config['alternate_locale'], $container);
+            }
         }
 
         $errorConfig = isset($config['error']) ? $config['error'] : array();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,6 +92,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('default_change_frequency')->defaultValue('always')->end()
                     ->end()
                 ->end()
+                ->booleanNode('enable_content_listener')->defaultTrue()->end()
             ->end()
         ;
 

--- a/Resources/config/content-listener.xml
+++ b/Resources/config/content-listener.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container
+        xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_seo.event_listener.seo_content.class">Symfony\Cmf\Bundle\SeoBundle\EventListener\ContentListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="cmf_seo.event_listener.seo_content" class="%cmf_seo.event_listener.seo_content.class%">
+            <argument type="service" id="cmf_seo.presentation"/>
+            <argument>%cmf_seo.content_key%</argument>
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest"/>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/schema/seo-1.0.xsd
+++ b/Resources/config/schema/seo-1.0.xsd
@@ -21,6 +21,7 @@
         <xsd:attribute name="content-key" type="xsd:string" />
         <xsd:attribute name="metadata-listener" type="enable_auto" />
         <xsd:attribute name="sonata-admin-extension" type="enable_auto" />
+        <xsd:attribute name="enable-content-listener" type="xsd:boolean" default="true" />
     </xsd:complexType>
 
     <xsd:complexType name="persistence">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,13 +7,10 @@
 
     <parameters>
         <parameter key="cmf_seo.config_values.class">Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\ConfigValues</parameter>
-
         <parameter key="cmf_seo.form.type.seo_metadata.class">Symfony\Cmf\Bundle\SeoBundle\Form\Type\SeoMetadataType</parameter>
         <parameter key="cmf_seo.cache.file.class">Symfony\Cmf\Bundle\SeoBundle\Cache\FileCache</parameter>
         <parameter key="cmf_seo.presentation.class">Symfony\Cmf\Bundle\SeoBundle\SeoPresentation</parameter>
-        <parameter key="cmf_seo.event_listener.seo_content.class">Symfony\Cmf\Bundle\SeoBundle\EventListener\ContentListener</parameter>
         <parameter key="cmf_seo.error.suggestion_provider.controller.class">Symfony\Cmf\Bundle\SeoBundle\Controller\SuggestionProviderController</parameter>
-
     </parameters>
 
     <services>
@@ -43,12 +40,6 @@
             <argument type="service" id="translator" />
             <argument type="service" id="cmf_seo.config_values" />
             <argument type="service" id="cmf_seo.cache" />
-        </service>
-
-        <service id="cmf_seo.event_listener.seo_content" class="%cmf_seo.event_listener.seo_content.class%">
-            <argument type="service" id="cmf_seo.presentation"/>
-            <argument>%cmf_seo.content_key%</argument>
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest"/>
         </service>
 
         <service id="cmf_seo.error.suggestion_provider.controller" class="%cmf_seo.error.suggestion_provider.controller.class%">

--- a/Tests/Unit/DependencyInjection/CmfSeoExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfSeoExtensionTest.php
@@ -244,4 +244,25 @@ class CmfSeoExtensionTest extends AbstractExtensionTestCase
             'cmf_seo.sitemap.url_information_provider'
         );
     }
+
+    public function testDisableSeoContentListener()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            array(
+                'DoctrinePHPCRBundle' => true,
+                'CmfRoutingBundle' => true,
+            )
+        );
+        $this->load(array(
+            'persistence'   => array(
+                'phpcr' => true,
+            ),
+            'enable_content_listener' => false
+        ));
+
+        $this->assertContainerBuilderNotHasService(
+            'cmf_seo.event_listener.seo_content'
+        );
+    }
 }

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -64,6 +64,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled' => false,
                 'default_change_frequency' => 'always'
             ),
+            'enable_content_listener' => true,
             );
 
         $sources = array_map(function ($path) {


### PR DESCRIPTION
We are working on integrating this into our CMS but would like to use our own content listener.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

## TO DO 

- [X] Add enable_content_listener boolean node
- [X] Update XML schema
- [X] Add tests
- [ ] Update docs