### PR TITLE
(Sitemap) No duplicate locations from dynamic routing

### DIFF
--- a/Doctrine/Phpcr/SitemapUrlInformationProvider.php
+++ b/Doctrine/Phpcr/SitemapUrlInformationProvider.php
@@ -109,13 +109,14 @@ class SitemapUrlInformationProvider implements UrlInformationProviderInterface
             }
 
             try {
-                $urlInformationList[] = $this->computeUrlInformationFromSitemapDocument($document);
+                $urlInformation = $this->computeUrlInformationFromSitemapDocument($document);
+                $urlInformationList[$urlInformation->getLocation()] = $urlInformation;
             } catch (\Exception $e) {
                 $this->logger->info($e->getMessage());
             }
         }
 
-        return $urlInformationList;
+        return array_values($urlInformationList);
     }
 
     /**


### PR DESCRIPTION
Hello,

With the dynamic router, the given resource has at least 2 routes (one for /cms/news/ID (for example) and one for /cms/routes/news/SLUG (for example too))

To avoid duplicate locations, I added the location as an array key. Don't know if that's a good thing (not very familiar with phpcr), this post will be more like an issue if my fix is dirty.

Regards,
Peekmo