### PR TITLE
adjust content_listener configuration

### DIFF
--- a/DependencyInjection/CmfSeoExtension.php
+++ b/DependencyInjection/CmfSeoExtension.php
@@ -79,7 +79,7 @@ class CmfSeoExtension extends Extension
             $this->loadSonataAdmin($config['sonata_admin_extension'], $loader, $container, $sonataBundles);
         }
 
-        if ($config['enable_content_listener']) {
+        if ($this->isConfigEnabled($container, $config['content_listener'])) {
 
             $loader->load('content-listener.xml');
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,7 +79,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('provider_id')->defaultNull()->end()
                     ->end()
                 ->end()
-                ->booleanNode('enable_content_listener')->defaultTrue()->end()
+                ->arrayNode('content_listener')
+                    ->canBeDisabled()
+                ->end()
             ->end()
         ;
 

--- a/Resources/config/schema/seo-1.0.xsd
+++ b/Resources/config/schema/seo-1.0.xsd
@@ -18,12 +18,16 @@
         <xsd:attribute name="content-key" type="xsd:string" />
         <xsd:attribute name="metadata-listener" type="enable_auto" />
         <xsd:attribute name="sonata-admin-extension" type="enable_auto" />
-        <xsd:attribute name="enable-content-listener" type="xsd:boolean" default="true" />
+        <xsd:attribute name="content-listener" type="content_listener" />
     </xsd:complexType>
 
     <xsd:complexType name="persistence">
         <xsd:attribute name="phpcr" type="xsd:boolean" />
         <xsd:attribute name="orm" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="content_listener">
+        <xsd:attribute name="enabled" type="xsd:boolean" default="true" />
     </xsd:complexType>
 
     <xsd:simpleType name="enable_auto">


### PR DESCRIPTION
i just realized that there is a content_key configuration that is also only relevant to the content_listener. i propose we consolidate that. for the 1.1 branch i just change what was committed now.

once this is good, i will update master and move the configuration for the key to the content_listener section, with BC code to still allow the old value.

doc: https://github.com/symfony-cmf/symfony-cmf-docs/pull/649

TODO: adjust changelog