### PR TITLE
issue#235 Made it set lastModification in xml sitemap

### DIFF
--- a/Doctrine/Phpcr/SitemapUrlInformationProvider.php
+++ b/Doctrine/Phpcr/SitemapUrlInformationProvider.php
@@ -157,6 +157,10 @@ class SitemapUrlInformationProvider implements UrlInformationProviderInterface
         $urlInformation->setLocation($this->router->generate($document, array(), true));
         $urlInformation->setChangeFrequency($this->defaultChanFrequency);
 
+        if (method_exists($document, 'getLastModification')) {
+            $urlInformation->setLastModification($document->getLastModification());
+        }
+
         if ($this->alternateLocaleProvider) {
             $collection = $this->alternateLocaleProvider->createForContent($document);
             $urlInformation->setAlternateLocales($collection->toArray());


### PR DESCRIPTION
I just added the few lines below to the method computeUrlInformationFromSitemapDocument() in Doctrine/Phpcr/SitemapUrlInformationProvider.php so that where the sitemap document has a method getLastModification(), this method is used to set lastModification in the $urlInformation.