### PR TITLE
use default templates

### DIFF
--- a/DependencyInjection/CmfSeoExtension.php
+++ b/DependencyInjection/CmfSeoExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\SeoBundle\DependencyInjection;
 
+use Symfony\Cmf\Bundle\SeoBundle\CmfSeoBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -270,15 +271,11 @@ class CmfSeoExtension extends Extension
             }
             unset($configurations[$key]['default_change_frequency']);
 
-            if (isset($config['defaults']['templates'])) {
-                // copy default configuration into this sitemap configuration to keep controller simple
-                foreach ($config['defaults']['templates'] as $format => $name) {
-                    if (!isset($configurations[$key]['templates'][$format])) {
-                        $configurations[$key]['templates'][$format] = $name;
-                    }
+            // copy default configuration into this sitemap configuration to keep controller simple
+            foreach ($config['defaults']['templates'] as $format => $name) {
+                if (!isset($configurations[$key]['templates'][$format])) {
+                    $configurations[$key]['templates'][$format] = $name;
                 }
-            } else {
-                $configurations[$key]['templates'] = array();
             }
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -114,6 +114,10 @@ class Configuration implements ConfigurationInterface
                                 ->arrayNode('templates')
                                     ->useAttributeAsKey('format')
                                     ->requiresAtLeastOneElement()
+                                    ->defaultValue(array(
+                                        'html' => 'CmfSeoBundle:Sitemap:index.html.twig',
+                                        'xml' => 'CmfSeoBundle:Sitemap:index.xml.twig',
+                                    ))
                                     ->prototype('scalar')->end()
                                 ->end()
                             ->end()

--- a/Tests/Resources/Fixtures/config/config_sitemap.xml
+++ b/Tests/Resources/Fixtures/config/config_sitemap.xml
@@ -1,7 +1,11 @@
 <container xmlns="http://symfony.com/schema/dic/services">
     <config xmlns="http://cmf.symfony.com/schema/dic/seo">
         <sitemap enabled="true">
-            <configuration default-change-frequency="never" name="default">
+            <defaults>
+                <template format="html">foo.html.twig</template>
+                <template format="xml">foo.xml.twig</template>
+            </defaults>
+            <configuration default-change-frequency="never" name="sitemap">
                 <template format="xml">test.xml</template>
                 <template format="html">test.html</template>
             </configuration>

--- a/Tests/Unit/DependencyInjection/CmfSeoExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfSeoExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Cmf\SeoBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Cmf\Bundle\SeoBundle\CmfSeoBundle;
 use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\CmfSeoExtension;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -335,6 +336,43 @@ class CmfSeoExtensionTest extends AbstractExtensionTestCase
             'cmf_seo.sitemap.guesser.some_other.default_change_frequency',
             0,
             'some-other-to-test'
+        );
+    }
+
+    public function testDefaultTemplatesSet()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            array(
+                'DoctrinePHPCRBundle' => true,
+                'CmfRoutingBundle' => true,
+            )
+        );
+        $this->load(array(
+            'persistence' => array(
+                'phpcr' => true,
+            ),
+            'alternate_locale' => array(
+                'enabled' => true
+            ),
+            'sitemap' => array(
+                'defaults' => array(
+                    'default_change_frequency' => 'global-frequency',
+                ),
+            )
+            ));
+
+
+        $this->assertContainerBuilderHasParameter(
+            'cmf_seo.sitemap.configurations',
+            array(
+                'sitemap' => array(
+                    'templates' => array(
+                        'html' => 'CmfSeoBundle:Sitemap:index.html.twig',
+                        'xml' => 'CmfSeoBundle:Sitemap:index.xml.twig',
+                    ),
+                ),
+            )
         );
     }
 

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -65,7 +65,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'configurations' => array(),
                 'defaults' => array(
                     'default_change_frequency' => 'always',
-                    'templates' => array(),
+                    'templates' => array(
+                        'html' => 'CmfSeoBundle:Sitemap:index.html.twig',
+                        'xml' => 'CmfSeoBundle:Sitemap:index.xml.twig',
+                    ),
                 ),
             ),
             'content_listener' => array(
@@ -91,7 +94,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'sitemap' => array(
                 'enabled'        => true,
                 'configurations' => array(
-                    'default' => array(
+                    'sitemap' => array(
                         'default_change_frequency' => 'never',
                         'templates' => array(
                             'xml'  => 'test.xml',
@@ -101,7 +104,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 ),
                 'defaults' => array(
                     'default_change_frequency' => 'always',
-                    'templates' => array(),
+                    'templates' => array(
+                        'html' => 'foo.html.twig',
+                        'xml' => 'foo.xml.twig',
+                    ),
                 ),
             ),
             'persistence' => array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #241 
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/pull/683

This PR should activate the default template if none are set