### PR TITLE
option to disable guessers/loaders/voters globaly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 Changelog
 =========
 
-* **2015-07-20**: Cleaned up the sitemap generation. If you used the unreleased version of 
-  sitemaps, you will need to adjust your code. See https://github.com/symfony-cmf/SeoBundle/pull/225
-* **2015-02-24**: Configuration for content_key moved to content_listener section, and its now possible to disable
-  The content listener by setting cmf_seo.content_listener.enabled: false
+* **2015-07-20**: Cleaned up the sitemap generation. If you used the unreleased 
+  version of sitemaps, you will need to adjust your code. See https://github.com/symfony-cmf/SeoBundle/pull/225
+  Options are available to keep all or no voters|guessers|loaders enabled or 
+  enable them one by one by their service id.
+* **2015-02-24**: Configuration for `content_key` moved to the `content_listener` 
+  section, and its now possible to disable the content listener by setting 
+  `cmf_seo.content_listener.enabled: false`
 * **2015-02-14**: Added sitemap generation
-* **2015-02-14**: [BC BREAK] Changed method visibility from private to public of SeoPresentation#getSeoMetadata()
-* **2014-10-04**: Custom exception controller for error handling
+* **2015-02-14**: [BC BREAK] Changed method visibility of 
+  `SeoPresentation#getSeoMetadata()` from private to public.
+* **2014-10-04**: Custom exception controller for error handling.
 
 1.1.0-RC3
 ---------

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\SeoBundle\DependencyInjection;
 
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Cmf\Bundle\SeoBundle\SeoPresentation;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -33,6 +34,30 @@ class Configuration implements ConfigurationInterface
 
         $nodeBuilder = $treeBuilder->root('cmf_seo')
             ->addDefaultsIfNotSet()
+            ->beforeNormalization()
+                ->ifTrue(function ($config) {
+                    return isset($config['sitemap'])
+                        && (!isset($config['sitemap']['configurations'])
+                            || 0 == count($config['sitemap']['configurations'])
+                        )
+                        && !isset($config['sitemap']['configuration']) // xml configuration
+                    ;
+                })
+                ->then(function ($config) {
+                    if (true === $config['sitemap']) {
+                        $config['sitemap'] = array(
+                            'enabled' => true,
+                            'configurations' => array(
+                                'sitemap' => array()
+                            ),
+                        );
+                    } elseif (is_array($config['sitemap'])) {
+                        $config['sitemap']['configurations'] = array('sitemap' => array());
+                    }
+
+                    return $config;
+                })
+            ->end()
             ->beforeNormalization()
                 ->ifTrue(function ($config) {
                     return isset($config['content_key']) && !isset($config['content_listener']['content_key']);
@@ -187,12 +212,18 @@ class Configuration implements ConfigurationInterface
                                 ))
                                 ->prototype('scalar')->end()
                             ->end()
+                            ->append($this->getSitemapHelperNode('loaders', array('_all')))
+                            ->append($this->getSitemapHelperNode('guessers', array('_all')))
+                            ->append($this->getSitemapHelperNode('voters', array('_all')))
                         ->end()
                     ->end()
                     ->arrayNode('configurations')
                         ->useAttributeAsKey('name')
                         ->prototype('array')
                             ->fixXmlConfig('template')
+                            ->fixXmlConfig('loader')
+                            ->fixXmlConfig('guesser')
+                            ->fixXmlConfig('voter')
                             ->children()
                                 ->scalarNode('default_change_frequency')->defaultNull()->end()
                                 ->arrayNode('templates')
@@ -200,12 +231,35 @@ class Configuration implements ConfigurationInterface
                                     ->requiresAtLeastOneElement()
                                     ->prototype('scalar')->end()
                                 ->end()
+                                ->append($this->getSitemapHelperNode('loaders', array()))
+                                ->append($this->getSitemapHelperNode('guessers', array()))
+                                ->append($this->getSitemapHelperNode('voters', array()))
                             ->end()
                         ->end()
                     ->end()
                 ->end()
             ->end()
         ;
+    }
+
+    private function getSitemapHelperNode($type, $default)
+    {
+        $node = new ArrayNodeDefinition($type);
+        $node
+            ->beforeNormalization()
+                ->ifTrue(function ($config) {
+                    return is_string($config);
+                })
+                ->then(function ($config) {
+                    return array($config);
+                })
+            ->end()
+            ->defaultValue($default)
+            ->prototype('scalar')->end()
+            ->end()
+        ;
+
+        return $node;
     }
 
     /**

--- a/Resources/config/schema/seo-1.0.xsd
+++ b/Resources/config/schema/seo-1.0.xsd
@@ -70,8 +70,12 @@
     <xsd:complexType name="sitemap_configuration">
         <xsd:sequence>
             <xsd:element name="template" type="sitemap_template" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="loader" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="voter" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="guesser" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="default-change-frequency" type="change_frequency" default="always" />
+
     </xsd:complexType>
 
     <xsd:complexType name="named_sitemap_configuration">

--- a/Tests/Resources/Fixtures/config/config2.xml
+++ b/Tests/Resources/Fixtures/config/config2.xml
@@ -14,6 +14,9 @@
         <configuration default-change-frequency="never" name="default">
             <template format="xml">test.xml</template>
             <template format="html">test.html</template>
+            <loader>_none</loader>
+            <voter>_none</voter>
+            <guesser>_none</guesser>
         </configuration>
     </sitemap>
 

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -69,6 +69,9 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'html' => 'CmfSeoBundle:Sitemap:index.html.twig',
                         'xml' => 'CmfSeoBundle:Sitemap:index.xml.twig',
                     ),
+                    'loaders' => array('_all'),
+                    'guessers' => array('_all'),
+                    'voters' => array('_all'),
                 ),
             ),
             'content_listener' => array(
@@ -100,6 +103,9 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             'xml'  => 'test.xml',
                             'html' => 'test.html',
                         ),
+                        'loaders' => array(),
+                        'guessers' => array(),
+                        'voters' => array(),
                     ),
                 ),
                 'defaults' => array(
@@ -108,6 +114,9 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'html' => 'foo.html.twig',
                         'xml' => 'foo.xml.twig',
                     ),
+                    'loaders' => array('_all'),
+                    'guessers' => array('_all'),
+                    'voters' => array('_all'),
                 ),
             ),
             'persistence' => array(
@@ -145,3 +154,4 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals($expectedConfiguration, $sources);
     }
 }
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #242 
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/issues/693

Started implementing with that and came to an easy global on/off/partial-off solution, we can start with. Doing some fance inheritance into the specific sitemap configurations will be an overkill atm - i think.

When you like that, i will do:
* [x] configuration schema extension
* [x] tests for configuration schema extension