### PR TITLE
Fix randomly failing test

### DIFF
--- a/Tests/Unit/Controller/SitemapControllerTest.php
+++ b/Tests/Unit/Controller/SitemapControllerTest.php
@@ -86,13 +86,15 @@ class SitemapControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testRequestXml()
     {
-        $response = new Response('some-xml-string');
-        $this->templating->expects($this->once())->method('render')->will($this->returnValue($response));
+        $this->templating->expects($this->once())
+            ->method('render')
+            ->with($this->equalTo('CmfSeoBundle:Sitemap:index.xml.twig'), $this->anything())
+            ->will($this->returnValue('some-xml-string'));
 
         /** @var Response $response */
         $response = $this->controller->indexAction('xml', 'test');
 
-        $this->assertEquals(new Response('some-xml-string'), $response->getContent());
+        $this->assertEquals('some-xml-string', $response->getContent());
     }
 
     public function testRequestHtml()


### PR DESCRIPTION
This tests randomly failed on HHVM. I have no idea why, but the tests was a bit... strange.

The controller passes `$templating->render` to `new Response()`, which is perfect (as `render()` returns a string).

The tests however mocked the render method and returned a `Response` object. This results in: `new Response(new Response(...));`. This is a bit strange and not compliant with the API docs of this method.

It works, as Response typecasts the object to a string and `Response::__toString` returns, besides lots of other stuff, also the response content. This however, did fail for HHVM sometimes.

Besides that, this method actually made the test test something. Before, it just tested that the templating was used, but not if the correct templates are used in the render call.