### PR TITLE
Add locale meta tag with simple locale information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* **2015-09-08: Add meta tag for language information
 * **2015-08-20**: Added templates configuration and `exclusion_rules` (based on the request matcher) to
   the error handling configuration
 * **2015-08-12**: Added configuration for the default data class of the `seo_metadata` form type.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -41,6 +41,7 @@
             <argument type="service" id="translator" />
             <argument type="service" id="cmf_seo.config_values" />
             <argument type="service" id="cmf_seo.cache" />
+            <argument>%locale%</argument>
         </service>
 
         <service id="cmf_seo.error.suggestion_provider.controller" class="%cmf_seo.error.suggestion_provider.controller.class%">

--- a/SeoPresentation.php
+++ b/SeoPresentation.php
@@ -85,6 +85,11 @@ class SeoPresentation implements SeoPresentationInterface
     private $cache;
 
     /**
+     * @var
+     */
+    private $locale;
+
+    /**
      * The constructor will set the injected SeoPage - the service of
      * sonata which is responsible for storing the seo data.
      *
@@ -92,17 +97,20 @@ class SeoPresentation implements SeoPresentationInterface
      * @param TranslatorInterface $translator
      * @param ConfigValues        $configValues
      * @param CacheInterface      $cache
+     * @param string              $locale
      */
     public function __construct(
         SeoPage $sonataPage,
         TranslatorInterface $translator,
         ConfigValues $configValues,
-        CacheInterface $cache = null
+        CacheInterface $cache = null,
+        $locale = null
     ) {
         $this->sonataPage = $sonataPage;
         $this->translator = $translator;
         $this->configValues = $configValues;
         $this->cache = $cache;
+        $this->locale = $locale;
     }
 
     /**
@@ -279,6 +287,10 @@ class SeoPresentation implements SeoPresentationInterface
                     );
                     break;
             }
+        }
+
+        if ($this->locale) {
+            $this->sonataPage->addMeta('http-equiv', 'language', $this->locale);
         }
     }
 

--- a/Tests/Unit/SeoPresentationTest.php
+++ b/Tests/Unit/SeoPresentationTest.php
@@ -347,7 +347,8 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             $this->pageService,
             $this->translator,
             $this->configValues,
-            $cache
+            $cache,
+            null
         );
 
         // predictions
@@ -388,7 +389,8 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             $this->pageService,
             $this->translator,
             $this->configValues,
-            $cache
+            $cache,
+            null
         );
 
         // predictions
@@ -418,5 +420,27 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
         ;
 
         $this->seoPresentation->updateSeoPage($content);
+    }
+
+    public function testLocaleMetaTag()
+    {
+        $seoPresentation = new SeoPresentation(
+            $this->pageService,
+            $this->translator,
+            $this->configValues,
+            null,
+            'en'
+        );
+
+        // predictions
+        $this->pageService
+            ->expects($this->once())
+            ->method('addMeta')
+            ->with('http-equiv', 'language', 'en')
+        ;
+
+        // test
+        $seoPresentation->updateSeoPage(new \stdClass());
+
     }
 }

--- a/Tests/WebTest/SeoFrontendTest.php
+++ b/Tests/WebTest/SeoFrontendTest.php
@@ -185,4 +185,21 @@ class SeoFrontendTest extends BaseTestCase
         $this->assertCount(0, $crawler->filter('html:contains("Exception-Test")')); // the default template was chosen
         $this->assertCount(1, $crawler->filter('html:contains("No route found for")'));
     }
+
+    public function testLanguageMetaTag()
+    {
+        $crawler = $this->getClient()->request('GET', '/en/alternate-locale-content');
+        $res = $this->getClient()->getResponse();
+
+        $this->assertEquals(200, $res->getStatusCode());
+
+        //test the meta tag entry
+        $metaCrawler = $crawler->filter('head > meta')->reduce(function (Crawler $node) {
+            return 'language' === $node->attr('http-equiv');
+        });
+
+        $actualMeta = $metaCrawler->extract('content', 'content');
+        $actualMeta = reset($actualMeta);
+        $this->assertEquals('en', $actualMeta);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #253 
| License       | MIT

Would just need to convert the locale information into RFC1766 standart language codes. But have no idiea how to do that, atm. The idea was to use something from `Intl::getLocaleBundle()`. 