### PR TITLE
Fix XSD and a simple deprecation notice

### DIFF
--- a/Doctrine/Phpcr/AlternateLocaleProvider.php
+++ b/Doctrine/Phpcr/AlternateLocaleProvider.php
@@ -79,7 +79,7 @@ class AlternateLocaleProvider implements AlternateLocaleProviderInterface
 
             $alternateLocaleCollection->add(
                 new AlternateLocale(
-                    $this->urlGenerator->generate($content, array('_locale' => $locale), true),
+                    $this->urlGenerator->generate($content, array('_locale' => $locale), UrlGeneratorInterface::ABSOLUTE_URL),
                     $locale
                 )
             );

--- a/Resources/config/schema/seo-1.0.xsd
+++ b/Resources/config/schema/seo-1.0.xsd
@@ -114,7 +114,6 @@
         <xsd:sequence>
             <xsd:element name="data_class" type="form_data_class" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
-        <xsd:attribute name="enabled" type="xsd:boolean" default="true" />
     </xsd:complexType>
 
     <xsd:complexType name="form_data_class">

--- a/Sitemap/LocationGuesser.php
+++ b/Sitemap/LocationGuesser.php
@@ -42,6 +42,6 @@ class LocationGuesser implements GuesserInterface
             return;
         }
 
-        $urlInformation->setLocation($this->urlGenerator->generate($object, array(), true));
+        $urlInformation->setLocation($this->urlGenerator->generate($object, array(), UrlGeneratorInterface::ABSOLUTE_URL));
     }
 }

--- a/Tests/Resources/Fixtures/config/config2.xml
+++ b/Tests/Resources/Fixtures/config/config2.xml
@@ -22,7 +22,7 @@
 
     <content-listener enabled="true" content-key="foo" />
 
-    <form enabled="true">
+    <form>
         <data_class>
             <seo_metadata>/My/Class</seo_metadata>
         </data_class>

--- a/Tests/Unit/Sitemap/LocationGuesserTest.php
+++ b/Tests/Unit/Sitemap/LocationGuesserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Cmf\Bundle\SeoBundle\Sitemap\LocationGuesser;
 
 class LocationGuesserTest extends GuesserTestCase
@@ -30,7 +31,7 @@ class LocationGuesserTest extends GuesserTestCase
         $urlGenerator
             ->expects($this->any())
             ->method('generate')
-            ->with($this, array(), true)
+            ->with($this, array(), UrlGeneratorInterface::ABSOLUTE_URL)
             ->will($this->returnValue('http://symfony.com'))
         ;
 


### PR DESCRIPTION
This feature was implemented to default to the Model class. However, that would never be the correct value. Either the PHPCR document has to be used or one of the custom documents created by the user for their persistence needs.

As you will have hard to debug errors when this setting has a wrong value, I propose to throw an exception instead of defaulting to some faulty value.

Meanwhile, I've fixed the XSD.

/cc @ElectricMaxxx 