### PR TITLE
Set Content-Language header instead of language meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.2.0
 -----
 
+* **2016-04-04**: Moved content-language from http-equiv to a real header.
 * **2016-03-31**: [Form] Form type for seo metadata set by_reference to false by default when ORM is active.
 * **2015-09-30**: Add `cmf_seo_update_metadata` twig function for updating seo metadata from templates using
 * **2015-09-08**: Add meta tag for language information

--- a/DependencyInjection/CmfSeoExtension.php
+++ b/DependencyInjection/CmfSeoExtension.php
@@ -59,9 +59,9 @@ class CmfSeoExtension extends Extension
 
         $sonataBundles = array();
         if ($this->isConfigEnabled($container, $config['persistence']['phpcr'])) {
-            $container->setParameter($this->getAlias().'.backend_type_phpcr', true);
+            $container->setParameter('cmf_seo.backend_type_phpcr', true);
             $container->setParameter(
-                $this->getAlias().'.persistence.phpcr.manager_name',
+                'cmf_seo.persistence.phpcr.manager_name',
                 $config['persistence']['phpcr']['manager_name']
             );
             $sonataBundles[] = 'SonataDoctrinePHPCRAdminBundle';
@@ -70,15 +70,15 @@ class CmfSeoExtension extends Extension
         }
 
         if ($this->isConfigEnabled($container, $config['persistence']['orm'])) {
-            $container->setParameter($this->getAlias().'.backend_type_orm', true);
+            $container->setParameter('cmf_seo.backend_type_orm', true);
             $container->setParameter(
-                $this->getAlias().'.persistence.orm.manager_name',
+                'cmf_seo.persistence.orm.manager_name',
                 $config['persistence']['orm']['manager_name']
             );
             $sonataBundles[] = 'SonataDoctrineORMBundle';
         }
 
-        $container->setParameter($this->getAlias().'.form_mode_orm',
+        $container->setParameter('cmf_seo.form_mode_orm',
             $this->isConfigEnabled($container, $config['persistence']['orm'])
             && !$this->isConfigEnabled($container, $config['persistence']['phpcr'])
         );
@@ -139,7 +139,7 @@ class CmfSeoExtension extends Extension
             }
         }
 
-        $container->setParameter($this->getAlias().'.sonata_admin_extension.form_group', $config['form_group']);
+        $container->setParameter('cmf_seo.sonata_admin_extension.form_group', $config['form_group']);
         $loader->load('admin.xml');
     }
 
@@ -155,7 +155,7 @@ class CmfSeoExtension extends Extension
 
         foreach ($params as $param) {
             $value = isset($config[$param]) ? $config[$param] : null;
-            $container->setParameter($this->getAlias().'.'.$param, $value);
+            $container->setParameter('cmf_seo.'.$param, $value);
         }
     }
 
@@ -196,7 +196,7 @@ class CmfSeoExtension extends Extension
 
     private function loadContentListener(array $config, XmlFileLoader $loader, ContainerBuilder $container)
     {
-        $container->setParameter($this->getAlias().'.content_key', $config['content_key']);
+        $container->setParameter('cmf_seo.content_key', $config['content_key']);
 
         $loader->load('content-listener.xml');
 
@@ -222,9 +222,9 @@ class CmfSeoExtension extends Extension
             throw new InvalidConfigurationException('Alternate locale provider enabled but none defined. You need to enable PHPCR or configure alternate_locale.provider_id');
         }
 
-        if ($container->has($this->getAlias().'.event_listener.seo_content')) {
+        if ($container->has('cmf_seo.event_listener.seo_content')) {
             $container
-                ->findDefinition($this->getAlias().'.event_listener.seo_content')
+                ->findDefinition('cmf_seo.event_listener.seo_content')
                 ->addMethodCall(
                     'setAlternateLocaleProvider',
                     array(new Reference($alternateLocaleProvider))
@@ -232,9 +232,9 @@ class CmfSeoExtension extends Extension
             ;
         }
 
-        if ($container->has($this->getAlias().'.sitemap.guesser.alternate_locales')) {
+        if ($container->has('cmf_seo.sitemap.guesser.alternate_locales')) {
             $container
-                ->findDefinition($this->getAlias().'.sitemap.guesser.alternate_locales')
+                ->findDefinition('cmf_seo.sitemap.guesser.alternate_locales')
                 ->replaceArgument(0, new Reference($alternateLocaleProvider))
             ;
         }
@@ -260,9 +260,9 @@ class CmfSeoExtension extends Extension
 
         $templates = isset($config['templates']) ? $config['templates'] : array();
         $exclusionRules = isset($config['exclusion_rules']) ? $config['exclusion_rules'] : array();
-        $container->setParameter($this->getAlias().'.error.templates', $templates);
+        $container->setParameter('cmf_seo.error.templates', $templates);
 
-        $exclusionMatcherDefinition = $container->getDefinition($this->getAlias().'.error.exclusion_matcher');
+        $exclusionMatcherDefinition = $container->getDefinition('cmf_seo.error.exclusion_matcher');
         foreach ($exclusionRules as $rule) {
             $rule['host'] = !isset($rule['host']) ? null : $rule['host'];
             $rule['methods'] = !isset($rule['methods']) ? null : $rule['methods'];
@@ -282,11 +282,11 @@ class CmfSeoExtension extends Extension
     {
         $arguments = array($path, $host, $methods, $ips, $attributes);
         $serialized = serialize($arguments);
-        $id = $this->getAlias().'.error.request_matcher.'.md5($serialized).sha1($serialized);
+        $id = 'cmf_seo.error.request_matcher.'.md5($serialized).sha1($serialized);
 
         if (!$container->hasDefinition($id)) {
             $container
-                ->setDefinition($id, new DefinitionDecorator($this->getAlias().'.error.request_matcher'))
+                ->setDefinition($id, new DefinitionDecorator('cmf_seo.error.request_matcher'))
                 ->setArguments($arguments)
             ;
         }
@@ -311,7 +311,7 @@ class CmfSeoExtension extends Extension
             $helperStatus[$helper] = array();
             $serviceDefinitionIds = $container->findTaggedServiceIds($tag);
             foreach ($serviceDefinitionIds as $id => $attributes) {
-                if (0 === strncmp($this->getAlias(), $id, strlen($this->getAlias()))) {
+                if (0 === strpos($id, 'cmf_seo')) {
                     // avoid interfering with services that are not part of this bundle
                     $helperStatus[$helper][$id] = array();
                 }
@@ -327,7 +327,7 @@ class CmfSeoExtension extends Extension
                     'sitemap' => $sitemapName,
                     'priority' => -1,
                 ));
-                $container->setDefinition($this->getAlias().'.sitemap.guesser.'.$sitemapName.'.default_change_frequency', $definition);
+                $container->setDefinition('cmf_seo.sitemap.guesser.'.$sitemapName.'.default_change_frequency', $definition);
             }
             unset($configurations[$sitemapName]['default_change_frequency']);
 
@@ -353,17 +353,17 @@ class CmfSeoExtension extends Extension
             }
         }
 
-        $container->setParameter($this->getAlias().'.sitemap.configurations', $configurations);
+        $container->setParameter('cmf_seo.sitemap.configurations', $configurations);
 
         $container->setParameter(
-            $this->getAlias().'.sitemap.default_change_frequency',
+            'cmf_seo.sitemap.default_change_frequency',
             $config['defaults']['default_change_frequency']
         );
 
         $this->handleSitemapHelper($helperStatus, $container);
 
         if (!$alternateLocale) {
-            $container->removeDefinition($this->getAlias().'.sitemap.guesser.alternate_locales');
+            $container->removeDefinition('cmf_seo.sitemap.guesser.alternate_locales');
         }
     }
 
@@ -409,6 +409,6 @@ class CmfSeoExtension extends Extension
             $seoMetadataClass = 'Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SeoMetadata';
         }
 
-        $container->setParameter($this->getAlias().'.form.data_class.seo_metadata', $seoMetadataClass);
+        $container->setParameter('cmf_seo.form.data_class.seo_metadata', $seoMetadataClass);
     }
 }

--- a/Doctrine/Phpcr/SitemapDocumentProvider.php
+++ b/Doctrine/Phpcr/SitemapDocumentProvider.php
@@ -50,7 +50,7 @@ class SitemapDocumentProvider implements LoaderInterface
         // the chain provider does not like collections as we array_merge in there
         foreach ($documentsCollection as $document) {
             $documents[] = $document;
-        };
+        }
 
         return $documents;
     }

--- a/EventListener/LanguageListener.php
+++ b/EventListener/LanguageListener.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\EventListener;
+
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This listener adds a Content-Language header to the response.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class LanguageListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if ($event->getResponse()->headers->has('Content-Language')) {
+            return;
+        }
+
+        $locale = $event->getRequest()->getLocale();
+        $language = current(explode('_', $locale, 2));
+        $event->getResponse()->headers->set('Content-Language', $language);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -43,7 +43,6 @@
             <argument type="service" id="translator" />
             <argument type="service" id="cmf_seo.config_values" />
             <argument type="service" id="cmf_seo.cache" />
-            <argument>%locale%</argument>
         </service>
 
         <service id="cmf_seo.error.suggestion_provider.controller" class="%cmf_seo.error.suggestion_provider.controller.class%">
@@ -64,6 +63,10 @@
         <service id="cmf_seo.twig.extension" class="%cmf_seo.twig.extension.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="cmf_seo.presentation" />
+        </service>
+
+        <service id="cmf_seo.language_listener" class="Symfony\Cmf\Bundle\SeoBundle\EventListener\LanguageListener">
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 

--- a/SeoPresentation.php
+++ b/SeoPresentation.php
@@ -85,11 +85,6 @@ class SeoPresentation implements SeoPresentationInterface
     private $cache;
 
     /**
-     * @var
-     */
-    private $locale;
-
-    /**
      * The constructor will set the injected SeoPage - the service of
      * sonata which is responsible for storing the seo data.
      *
@@ -97,20 +92,17 @@ class SeoPresentation implements SeoPresentationInterface
      * @param TranslatorInterface $translator
      * @param ConfigValues        $configValues
      * @param CacheInterface      $cache
-     * @param string              $locale
      */
     public function __construct(
         SeoPage $sonataPage,
         TranslatorInterface $translator,
         ConfigValues $configValues,
-        CacheInterface $cache = null,
-        $locale = null
+        CacheInterface $cache = null
     ) {
         $this->sonataPage = $sonataPage;
         $this->translator = $translator;
         $this->configValues = $configValues;
         $this->cache = $cache;
-        $this->locale = $locale;
     }
 
     /**
@@ -287,10 +279,6 @@ class SeoPresentation implements SeoPresentationInterface
                     );
                     break;
             }
-        }
-
-        if ($this->locale) {
-            $this->sonataPage->addMeta('http-equiv', 'language', $this->locale);
         }
     }
 

--- a/Tests/Unit/EventListener/LanguageListenerTest.php
+++ b/Tests/Unit/EventListener/LanguageListenerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Cmf\Bundle\SeoBundle\EventListener\LanguageListener;
+
+class LanguageListenerTest extends \PHPUnit_Framework_Testcase
+{
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->listener = new LanguageListener();
+    }
+
+    /**
+     * @dataProvider provideRequestLocales
+     */
+    public function testSetsContentLanguageHeader($locale)
+    {
+        $request = Request::create('/');
+        $request->setLocale($locale);
+
+        $response = new Response();
+
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\FilterResponseEvent')->disableOriginalConstructor()->getMock();
+        $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+        $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
+
+        $this->listener->onKernelResponse($event);
+
+        $this->assertEquals('en', $response->headers->get('Content-Language'));
+    }
+
+    public function provideRequestLocales()
+    {
+        return array(
+            array('en'),
+            array('en_US'),
+        );
+    }
+
+    public function testDoesNotOverridePreSetContentLanguage()
+    {
+        $request = Request::create('/');
+        $request->setLocale('en');
+
+        $response = new Response();
+        $response->headers->set('Content-Language', 'nl');
+
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\FilterResponseEvent')->disableOriginalConstructor()->getMock();
+        $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+        $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
+
+        $this->listener->onKernelResponse($event);
+
+        $this->assertEquals('nl', $response->headers->get('Content-Language'));
+    }
+}

--- a/Tests/Unit/SeoPresentationTest.php
+++ b/Tests/Unit/SeoPresentationTest.php
@@ -347,8 +347,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             $this->pageService,
             $this->translator,
             $this->configValues,
-            $cache,
-            null
+            $cache
         );
 
         // predictions
@@ -389,8 +388,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             $this->pageService,
             $this->translator,
             $this->configValues,
-            $cache,
-            null
+            $cache
         );
 
         // predictions
@@ -420,26 +418,5 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
         ;
 
         $this->seoPresentation->updateSeoPage($content);
-    }
-
-    public function testLocaleMetaTag()
-    {
-        $seoPresentation = new SeoPresentation(
-            $this->pageService,
-            $this->translator,
-            $this->configValues,
-            null,
-            'en'
-        );
-
-        // predictions
-        $this->pageService
-            ->expects($this->once())
-            ->method('addMeta')
-            ->with('http-equiv', 'language', 'en')
-        ;
-
-        // test
-        $seoPresentation->updateSeoPage(new \stdClass());
     }
 }

--- a/Tests/WebTest/SeoFrontendTest.php
+++ b/Tests/WebTest/SeoFrontendTest.php
@@ -186,20 +186,12 @@ class SeoFrontendTest extends BaseTestCase
         $this->assertCount(1, $crawler->filter('html:contains("No route found for")'));
     }
 
-    public function testLanguageMetaTag()
+    public function testContentLanguageHeader()
     {
         $crawler = $this->getClient()->request('GET', '/en/alternate-locale-content');
         $res = $this->getClient()->getResponse();
 
         $this->assertEquals(200, $res->getStatusCode());
-
-        //test the meta tag entry
-        $metaCrawler = $crawler->filter('head > meta')->reduce(function (Crawler $node) {
-            return 'language' === $node->attr('http-equiv');
-        });
-
-        $actualMeta = $metaCrawler->extract('content', 'content');
-        $actualMeta = reset($actualMeta);
-        $this->assertEquals('en', $actualMeta);
+        $this->assertEquals('en', $res->headers->get('Content-Language'));
     }
 }


### PR DESCRIPTION
The `%locale%` parameter is just a convention used in the Standard Edition. This bundle can not assume that this parameter is available. Instead, a custom config option should be introduced.

This bug was introduced in https://github.com/symfony-cmf/SeoBundle/pull/262. I found this while trying to update the CMF website.

/cc @dbu please merge this before releasing stable